### PR TITLE
ci: fix aarch64 cross-compilation by specifying Python interpreters

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,20 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_release:
+        description: 'Force release build (use existing tag)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      release_tag:
+        description: 'Tag to release (e.g., cachekit-v0.1.0)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -38,7 +52,8 @@ jobs:
   build-wheels:
     name: Build wheels (${{ matrix.target }})
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    # Run if: release-please created a release OR manual dispatch with force_release
+    if: needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true'
     strategy:
       matrix:
         include:
@@ -60,7 +75,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          # Use release-please tag or manual input tag
+          ref: ${{ needs.release-please.outputs.tag_name || github.event.inputs.release_tag }}
 
       # Python setup required for native builds (macOS/Windows) to discover interpreters
       # Linux uses Docker containers which have Python pre-installed
@@ -90,12 +106,12 @@ jobs:
   build-sdist:
     name: Build source distribution
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ needs.release-please.outputs.tag_name || github.event.inputs.release_tag }}
 
       - uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
## Problem

The release workflow failed when building wheels for `aarch64-unknown-linux-gnu`:

```
💥 maturin failed
  Caused by: Couldn't find any python interpreters. Please specify at least one with -i
```

## Fixes

| Fix | Platform | Issue |
|-----|----------|-------|
| `-i python3.9...3.13` | aarch64-linux | Cross-compilation container has no discoverable Python |
| `rust-toolchain: stable` | All | Ensures consistent Rust version |
| `setup-python` | macOS/Windows | Native builds need installed interpreters |
| `workflow_dispatch` | All | **Enables manual re-triggering of failed releases** |

## Manual Release Trigger

After merge, go to **Actions → Release → Run workflow** with:
- `force_release`: `true`
- `release_tag`: `cachekit-v0.1.0`

This will rebuild all wheels and publish to PyPI.

## Test Plan

- [ ] Merge this PR
- [ ] Manually trigger workflow with `force_release=true`, `release_tag=cachekit-v0.1.0`
- [ ] Verify all wheel builds succeed
- [ ] Verify publish to PyPI succeeds