### PR TITLE
ci: use manylinux_2_28 for aarch64 cross-compilation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,9 +68,11 @@ jobs:
             target: x86_64-pc-windows-msvc
           # Cross-compilation - must specify Python versions explicitly
           # (cross containers don't have discoverable Python interpreters)
+          # Uses manylinux_2_28 for modern GCC (fixes ring crate aarch64 build)
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             interpreter: -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13
+            manylinux: "2_28"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -95,7 +97,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist ${{ matrix.interpreter }}
-          manylinux: auto
+          manylinux: ${{ matrix.manylinux || 'auto' }}
           rust-toolchain: stable
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Fix `ring` crate aarch64 cross-compilation failure by using manylinux_2_28 instead of manylinux2014.

## Problem
manylinux2014 uses old GCC that doesn't define `__ARM_ARCH` for aarch64 assembler, causing:
```
#error "ARM assembler must define __ARM_ARCH"
```

## Solution
Use manylinux_2_28 (AlmaLinux 8) which has GCC 8+ with proper aarch64 support.

**Compatibility**: Requires glibc 2.28+ (RHEL 8+, Ubuntu 18.04+, Debian 10+) - fine for Python 3.9+.

## Test plan
- [ ] Trigger manual release workflow to verify aarch64 wheel builds