### PR TITLE
chore: update PyPI metadata to match README

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "cachekit"
 version = "0.1.0"
-description = "Production-ready Redis caching for Python with intelligent reliability features"
+description = "Production-ready Redis caching for Python with intelligent reliability features and Rust-powered performance"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [
@@ -23,9 +23,15 @@ keywords = [
     "performance",
     "reliability",
     "production",
+    "encryption",
+    "security",
+    "circuit-breaker",
+    "prometheus",
+    "messagepack",
+    "distributed-locking",
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -40,6 +46,8 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Database :: Database Engines/Servers",
     "Topic :: System :: Distributed Computing",
+    "Topic :: System :: Monitoring",
+    "Topic :: Security :: Cryptography",
     "Framework :: AsyncIO",
     "Typing :: Typed",
 ]
@@ -75,6 +83,7 @@ Homepage = "https://github.com/cachekit-io/cachekit-py"
 Documentation = "https://github.com/cachekit-io/cachekit-py#readme"
 Repository = "https://github.com/cachekit-io/cachekit-py.git"
 Issues = "https://github.com/cachekit-io/cachekit-py/issues"
+Changelog = "https://github.com/cachekit-io/cachekit-py/blob/main/CHANGELOG.md"
 
 # Maturin configuration for Rust extensions
 [tool.maturin]


### PR DESCRIPTION
## Summary
- Add "Rust-powered performance" to description
- Change Development Status from Beta → Alpha (matches README warning)
- Add keywords for discoverability: encryption, security, circuit-breaker, prometheus, messagepack, distributed-locking
- Add topic classifiers: Monitoring, Cryptography
- Add Changelog URL to project.urls

Also updated GitHub repo "About" section with matching description, homepage (PyPI), and topics.