### PR TITLE
chore: use simple vX.Y.Z tags for releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,7 +19,8 @@
   "packages": {
     ".": {
       "package-name": "cachekit",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false
     }
   },
   "extra-files": [


### PR DESCRIPTION
## Problem

Release-please PR #15 is trying to release 0.2.0 with 0.1.0 commits because it can't find the `cachekit-v0.1.0` tag.

**Actual tag**: `v0.1.0`
**Expected by release-please**: `cachekit-v0.1.0`

## Solution

Set `include-component-in-tag: false` since this is a single-package repo. Simple `vX.Y.Z` tags are cleaner.

## After merge

1. Close PR #15
2. Release-please will regenerate with correct commit range (finding `v0.1.0`)