### PR TITLE
ci: add Codecov integration for coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,9 @@ jobs:
     name: Tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write  # Required for Codecov OIDC
     strategy:
       fail-fast: false
       matrix:
@@ -163,11 +166,35 @@ jobs:
       run: |
         uv sync --group dev
 
-    - name: Run critical tests
+    - name: Run critical tests with coverage
       env:
         REDIS_URL: redis://localhost:6379
       run: |
-        make test-critical
+        uv run pytest tests/critical/ -m "not slow" \
+          --cov=src/cachekit \
+          --cov-report=xml \
+          --cov-report=term \
+          --junitxml=junit.xml \
+          -o junit_family=legacy
+
+    - name: Upload coverage to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v5
+      with:
+        files: ./coverage.xml
+        use_oidc: true
+        fail_ci_if_error: false
+        flags: python-${{ matrix.python-version }}
+
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/codecov-action@v5
+      with:
+        files: ./junit.xml
+        report_type: test_results
+        use_oidc: true
+        flags: python-${{ matrix.python-version }}
+        fail_ci_if_error: false
 
   # Markdown documentation tests
   test-docs:

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ htmlcov/
 nosetests.xml
 coverage-rust-html/
 coverage.xml
+junit.xml
 *.coveragerc
 
 # IDEs

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Production-ready Redis caching for Python with intelligent reliability features 
 
 [![PyPI Version][pypi-badge]][pypi-url]
 [![Python Versions][python-badge]][pypi-url]
+[![codecov][codecov-badge]][codecov-url]
 [![License: MIT][license-badge]][license-url]
 
 </div>
@@ -382,3 +383,5 @@ MIT License - see [LICENSE][license-file-url] for details.
 [license-file-url]: LICENSE
 [github-url]: https://github.com/cachekit-io/cachekit-py
 [issues-url]: https://github.com/cachekit-io/cachekit-py/issues
+[codecov-badge]: https://codecov.io/github/cachekit-io/cachekit-py/graph/badge.svg
+[codecov-url]: https://codecov.io/github/cachekit-io/cachekit-py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,32 @@ doctest_optionflags = [
     "ELLIPSIS",
 ]
 
+# Coverage configuration
+[tool.coverage.run]
+source = ["src/cachekit"]
+branch = true
+omit = [
+    "*/tests/*",
+    "*/__pycache__/*",
+    "*/.venv/*",
+]
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "@abstractmethod",
+    "@overload",
+    "class .*\\bProtocol\\b.*:",
+]
+
 [dependency-groups]
 dev = [
     # Testing


### PR DESCRIPTION
## Summary

- Add `[tool.coverage.run]` and `[tool.coverage.report]` sections to pyproject.toml
- Modify `test-critical` job with OIDC permissions and codecov upload steps
- Upload both coverage.xml (coverage) and junit.xml (test results) to Codecov
- Add codecov badge to README
- Add junit.xml to .gitignore

## Implementation Details

| Feature | Value |
|---------|-------|
| Authentication | OIDC (no secrets needed) |
| Failure handling | Non-blocking (`fail_ci_if_error: false`) |
| Coverage flags | `python-${{ matrix.python-version }}` |
| Upload condition | `if: !cancelled()` (uploads even on test failure) |

## Test Plan

- [x] Local pytest with coverage flags generates coverage.xml and junit.xml
- [ ] CI workflow runs successfully
- [ ] Codecov receives upload (auto-creates repo on first upload)
- [ ] Badge displays in README after first successful upload