### PR TITLE
ci: run full test suite on main, critical-only on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,11 +166,24 @@ jobs:
       run: |
         uv sync --group dev
 
-    - name: Run critical tests with coverage
+    - name: Run critical tests (PRs)
+      if: github.event_name == 'pull_request'
       env:
         REDIS_URL: redis://localhost:6379
       run: |
         uv run pytest tests/critical/ -m "not slow" \
+          --cov=src/cachekit \
+          --cov-report=xml \
+          --cov-report=term \
+          --junitxml=junit.xml \
+          -o junit_family=legacy
+
+    - name: Run full test suite (main)
+      if: github.event_name == 'push'
+      env:
+        REDIS_URL: redis://localhost:6379
+      run: |
+        uv run pytest tests/ -m "not slow" \
           --cov=src/cachekit \
           --cov-report=xml \
           --cov-report=term \
@@ -184,7 +197,7 @@ jobs:
         files: ./coverage.xml
         use_oidc: true
         fail_ci_if_error: false
-        flags: python-${{ matrix.python-version }}
+        flags: ${{ github.event_name == 'push' && 'full' || 'critical' }}-python-${{ matrix.python-version }}
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
@@ -193,7 +206,7 @@ jobs:
         files: ./junit.xml
         report_type: test_results
         use_oidc: true
-        flags: python-${{ matrix.python-version }}
+        flags: ${{ github.event_name == 'push' && 'full' || 'critical' }}-python-${{ matrix.python-version }}
         fail_ci_if_error: false
 
   # Markdown documentation tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,39 @@
+# Codecov Configuration
+# https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%  # Allow 2% coverage drop without failing
+    patch:
+      default:
+        target: 80%  # New code should have 80% coverage
+
+# Flag configuration for PR vs main coverage strategy
+flag_management:
+  default_rules:
+    carryforward: true  # Carry forward coverage from previous uploads
+    statuses:
+      - type: project
+      - type: patch
+
+  individual_flags:
+    # Full test suite (main branch only)
+    - name: full-python-3.12
+      carryforward: true
+      paths:
+        - src/cachekit/
+
+    # Critical tests (PRs) - carryforward from full coverage
+    - name: critical-python-3.12
+      carryforward: true
+      carryforward_mode: labels
+      paths:
+        - src/cachekit/
+
+comment:
+  layout: "header, diff, flags, components"
+  behavior: default
+  require_changes: true  # Only comment if coverage changed


### PR DESCRIPTION
## Summary

Fixes low coverage (~52%) by running full test suite on merge to main.

| Event | Tests Run | Coverage | CI Time |
|-------|-----------|----------|---------|
| PR | `tests/critical/` | ~52% | ~1-2 min |
| Main push | `tests/` (all) | ~77% | ~10 min |

## Changes

- **ci.yml**: Conditional test execution based on `github.event_name`
  - `pull_request` → critical tests only (fast feedback)
  - `push` → full test suite (accurate coverage)
- **codecov.yml**: New configuration file
  - Carryforward flags to preserve coverage between uploads
  - 2% threshold for project coverage
  - 80% target for patch (new code) coverage

## Codecov Flag Strategy

```
PRs:   flags: critical-python-X.Y  (fast, partial coverage)
Main:  flags: full-python-X.Y      (slow, full coverage)
```

Codecov carryforward ensures badge shows full coverage from main, not partial from PRs.

## Test Plan

- [ ] PR CI runs critical tests only (~1-2 min)
- [ ] Main merge CI runs full tests (~10 min)
- [ ] Codecov shows ~77% coverage after main merge