### PR TITLE
refactor: rename SerializationWrapper methods to be backend-agnostic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,10 @@ repos:
   - repo: local
     hooks:
       # Python type checking with basedpyright
+      # Uses venv directly to avoid uv run modifying uv.lock
       - id: basedpyright
         name: basedpyright
-        entry: uv run basedpyright src/
+        entry: .venv/bin/basedpyright src/ --level error
         language: system
         types: [python]
         pass_filenames: false

--- a/tests/unit/test_context_leak_regression.py
+++ b/tests/unit/test_context_leak_regression.py
@@ -618,9 +618,9 @@ def ttl_refresh_mock_backend():
     # Serialize the value - returns (bytes, SerializationMetadata)
     serializer = StandardSerializer()
     raw_bytes, metadata = serializer.serialize(42)
-    # Convert metadata to dict for wrap_for_redis (needs "format" key)
+    # Convert metadata to dict for wrap (needs "format" key)
     metadata_dict = metadata.to_dict()
-    wrapped_data = SerializationWrapper.wrap_for_redis(
+    wrapped_data = SerializationWrapper.wrap(
         data=raw_bytes,
         metadata=metadata_dict,  # Must include "format" key from actual metadata
         serializer_name="default",  # Match StandardSerializer
@@ -810,7 +810,7 @@ def backend_without_ttl():
     serializer = StandardSerializer()
     raw_bytes, metadata = serializer.serialize(42)
     metadata_dict = metadata.to_dict()
-    wrapped_data = SerializationWrapper.wrap_for_redis(
+    wrapped_data = SerializationWrapper.wrap(
         data=raw_bytes,
         metadata=metadata_dict,
         serializer_name="default",


### PR DESCRIPTION
## Summary
- Removes Redis-specific naming from the generic `SerializationWrapper`
- `wrap_for_redis()` → `wrap()`  
- `unwrap_from_redis()` → `unwrap()`
- Updates docstrings/comments in `cache_handler.py` to use "cache" instead of "Redis"

The `SerializationWrapper` creates a JSON envelope with base64-encoded payload - this format is backend-agnostic and works with any cache backend (Redis, CachekitIO, Memcached, etc.). The "redis" naming was a leaky abstraction.

## Pre-commit fix
Also fixes the basedpyright pre-commit hook to:
- Use venv directly (`.venv/bin/basedpyright`) instead of `uv run` to avoid modifying `uv.lock`
- Add `--level error` to match Makefile behavior (fail on errors only, not warnings)

## Test plan
- [x] `make quick-check` passes
- [x] All existing tests pass
- [x] Pre-commit hooks pass