### PR TITLE
ci: build wheels for all Python versions on macOS/Windows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,13 +61,16 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             interpreter: -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13
-          # macOS/Windows - uses setup-python (line 85-94) which only installs 3.9-3.13
+          # macOS/Windows - must specify interpreters explicitly (auto-discovery unreliable)
           - os: macos-latest
             target: x86_64-apple-darwin
+            interpreter: -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13
           - os: macos-latest
             target: aarch64-apple-darwin
+            interpreter: -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+            interpreter: -i python3.9 -i python3.10 -i python3.11 -i python3.12 -i python3.13
           # aarch64 Linux cross-compilation - must specify Python versions explicitly
           # (cross containers don't have discoverable Python interpreters)
           # Uses manylinux_2_28 for modern GCC (fixes ring crate aarch64 build)


### PR DESCRIPTION
## Summary
- Add explicit interpreter flags for macOS and Windows wheel builds
- Fixes missing wheels for Python 3.9-3.12 on these platforms

## Problem
Users on Windows/macOS with Python 3.9-3.12 had no pre-built wheels, forcing source builds which failed due to `home` crate 0.5.12 requiring Rust edition 2024 (Cargo 1.85+, not yet stable).

## Solution
Maturin's `--find-interpreter` auto-discovery is unreliable with multiple Python versions from `setup-python`. Explicit `-i python3.X` flags ensure all versions get wheels.

## Impact
| Platform | Before | After |
|----------|--------|-------|
| Linux x86_64 | 5 wheels | 5 wheels |
| Linux aarch64 | 5 wheels | 5 wheels |
| macOS x86_64 | 1 wheel (3.13) | 5 wheels |
| macOS aarch64 | 1 wheel (3.13) | 5 wheels |
| Windows x86_64 | 1 wheel (3.13) | 5 wheels |
| **Total** | 13 | 25 |