### PR TITLE
ci: add checks:write permission for rustsec/audit-check

### DIFF
--- a/.github/workflows/security-fast.yml
+++ b/.github/workflows/security-fast.yml
@@ -9,7 +9,8 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  security-events: write  # Required for rustsec/audit-check SARIF upload
+  checks: write  # Required for rustsec/audit-check to create check runs
+  security-events: write
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- Add `checks: write` permission to security-fast.yml workflow
- Fixes "Resource not accessible by integration" error from rustsec/audit-check

## Problem

The `rustsec/audit-check@v2` action creates check runs via the GitHub Checks API (`POST /repos/{owner}/{repo}/check-runs`), which requires the `checks: write` permission. The workflow only had `security-events: write`, which is for SARIF uploads (a different API).

## Fix

Added `checks: write` to the permissions block.

Closes the failing run: https://github.com/cachekit-io/cachekit-py/actions/runs/20328172614/job/58397508291