### PR TITLE
ci: resolve 3 CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
         REDIS_URL: redis://localhost:6379
       run: |
         uv run pytest tests/ -m "not slow" \
+          --ignore=tests/fuzzing \
           --cov=src/cachekit \
           --cov-report=xml \
           --cov-report=term \

--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -97,7 +97,7 @@ jobs:
         enable-cache: true
 
     - name: Set up Python
-      run: uv python install 3.12
+      run: uv python install 3.11
 
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@stable
@@ -111,9 +111,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .venv
-        key: venv-${{ runner.os }}-py3.12-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
+        key: venv-${{ runner.os }}-py3.11-${{ hashFiles('**/pyproject.toml', '**/uv.lock') }}
         restore-keys: |
-          venv-${{ runner.os }}-py3.12-
+          venv-${{ runner.os }}-py3.11-
 
     - name: Install dependencies
       run: |
@@ -183,8 +183,8 @@ jobs:
         rustup toolchain install nightly
         rustup default nightly
 
-    - name: Add source for MSan
-      if: matrix.sanitizer == 'memory'
+    - name: Add source for sanitizers
+      if: matrix.sanitizer == 'memory' || matrix.sanitizer == 'thread'
       run: rustup component add rust-src --toolchain nightly
 
     - name: Cache Rust dependencies
@@ -210,7 +210,7 @@ jobs:
       run: |
         cd rust
         cargo +nightly test --lib --target x86_64-unknown-linux-gnu \
-          --no-default-features --features compression,checksum,messagepack,encryption
+          -Zbuild-std --no-default-features --features compression,checksum,messagepack,encryption
 
     - name: Run MemorySanitizer
       if: matrix.sanitizer == 'memory'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "cachekit-rs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cachekit-core",
  "criterion",

--- a/uv.lock
+++ b/uv.lock
@@ -235,7 +235,7 @@ filecache = [
 
 [[package]]
 name = "cachekit"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "blake3" },


### PR DESCRIPTION
## Summary

- **CI workflow**: Add `--ignore=tests/fuzzing` to full test suite — fuzzing tests import `atheris` which isn't in dev deps, causing exit code 2 on all 6 Python matrix jobs
- **Security Deep / Atheris**: Pin to Python 3.11 — `atheris==2.3.0` uses CPython `PRECALL` opcode removed in 3.12
- **Security Deep / TSan**: Add `-Zbuild-std` and `rust-src` component — Rust nightly 1.95+ enforces sanitizer ABI consistency across all linked crates

## Test plan

- [ ] CI workflow: all 6 Python version test jobs pass (no collection errors)
- [ ] Security Deep / Atheris: builds atheris successfully on Python 3.11
- [ ] Security Deep / TSan: compiles with matching sanitizer flags