### PR TITLE
Fix 4 test suite bugs, use lab runners for push CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,11 @@ jobs:
         cd rust && cargo clippy -- -D warnings
 
   # Critical test suite (parallel matrix)
+  # Push to main: runs on lab self-hosted runners (consistent perf, free minutes)
+  # PRs: runs on GitHub-hosted runners (untrusted code never touches lab infra)
   test-critical:
     name: Tests (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && 'cachekit' || 'ubuntu-latest' }}
     timeout-minutes: 15
     permissions:
       contents: read

--- a/tests/unit/test_consolidated_decorator.py
+++ b/tests/unit/test_consolidated_decorator.py
@@ -9,6 +9,8 @@ This test suite validates:
 Requirements: 5.1, 5.2, 5.3
 """
 
+from __future__ import annotations
+
 import asyncio
 import time
 from unittest.mock import patch
@@ -32,11 +34,11 @@ class TestConsolidatedDecoratorFeatureCombinations:
 
         # Use intent-based presets instead of individual feature flags
         if use_preset == "minimal":
-            decorator = cache.minimal(ttl=300, namespace="feature_test")
+            decorator = cache.minimal(ttl=300, namespace="feature_test_minimal")
         elif use_preset == "production":
-            decorator = cache.production(ttl=300, namespace="feature_test")
+            decorator = cache.production(ttl=300, namespace="feature_test_production")
         else:
-            decorator = cache(ttl=300, namespace="feature_test")
+            decorator = cache(ttl=300, namespace="feature_test_default")
 
         @decorator
         def test_function(x: int) -> str:
@@ -95,11 +97,11 @@ class TestConsolidatedDecoratorFeatureCombinations:
 
         # Use intent-based presets instead of individual feature flags
         if use_preset == "minimal":
-            decorator = cache.minimal(ttl=300, namespace="async_feature_test")
+            decorator = cache.minimal(ttl=300, namespace="async_feature_test_minimal")
         elif use_preset == "production":
-            decorator = cache.production(ttl=300, namespace="async_feature_test")
+            decorator = cache.production(ttl=300, namespace="async_feature_test_production")
         else:
-            decorator = cache(ttl=300, namespace="async_feature_test")
+            decorator = cache(ttl=300, namespace="async_feature_test_default")
 
         @decorator
         async def async_test_function(x: int) -> str:


### PR DESCRIPTION
## Summary

- **Python 3.9 fix**: Add `from __future__ import annotations` to `test_consolidated_decorator.py` — PEP 604 `str | None` syntax crashed collection on 3.9
- **Test isolation fix**: Unique namespaces per parametrize case in consolidated decorator tests — `[None]` case was hitting stale cached data from `[minimal]`/`[production]` runs
- **Numpy test update**: `test_blake2b_with_numpy_arrays_raises_type_error` expected arrays to be rejected, but constrained array support was added (round-table 2025-12-18). Now tests valid arrays succeed and invalid (2D) arrays are rejected
- **Error message regex**: datetime/set rejection messages were improved to be type-specific but test regexes still matched the old generic message
- **Lab runners**: Test matrix uses self-hosted `cachekit` runners on push (consistent perf on Ryzen 5950X), `ubuntu-latest` on PRs (untrusted code never touches lab)

## Test plan

- [ ] PR CI passes on `ubuntu-latest` (this run)
- [ ] Python 3.9 collection no longer crashes
- [ ] `test_all_feature_combinations_*[None]` passes
- [ ] Blake2b numpy/unsupported type tests pass
- [ ] After merge, push CI runs on `cachekit` self-hosted runners