### PR TITLE
chore: fix testing infrastructure inconsistencies

### DIFF
--- a/tests/critical/conftest.py
+++ b/tests/critical/conftest.py
@@ -1,11 +1,11 @@
 """Pytest configuration for critical path tests.
 
-Override autouse fixtures that aren't needed for FileBackend/MemcachedBackend tests.
+Override autouse fixtures that aren't needed for non-Redis backend tests.
 """
 
 
 def pytest_runtest_setup(item):
-    """Skip redis setup for file backend and cachekitio metrics tests."""
+    """Skip redis setup for non-Redis backend critical tests."""
     skip_redis = (
         "file_backend" in item.nodeid
         or "cachekitio_metrics" in item.nodeid

--- a/tests/critical/test_file_backend_critical.py
+++ b/tests/critical/test_file_backend_critical.py
@@ -19,7 +19,7 @@ from cachekit.backends.file.config import FileBackendConfig
 
 
 @pytest.fixture
-def backend(tmp_path, monkeypatch):
+def backend(tmp_path):
     """Create FileBackend instance for testing.
 
     Uses tmp_path fixture to isolate cache directory per test.

--- a/tests/unit/backends/test_cachekitio_config.py
+++ b/tests/unit/backends/test_cachekitio_config.py
@@ -9,6 +9,8 @@ from cachekit.backends.cachekitio.config import (
     is_private_ip,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestIsPrivateIP:
     """Tests for is_private_ip function."""

--- a/tests/unit/backends/test_cachekitio_error_handler.py
+++ b/tests/unit/backends/test_cachekitio_error_handler.py
@@ -6,6 +6,8 @@ import pytest
 from cachekit.backends.cachekitio.error_handler import classify_http_error
 from cachekit.backends.errors import BackendError, BackendErrorType
 
+pytestmark = pytest.mark.unit
+
 
 def _response(status_code: int) -> httpx.Response:
     return httpx.Response(status_code=status_code, request=httpx.Request("GET", "http://test"))

--- a/tests/unit/backends/test_file_config.py
+++ b/tests/unit/backends/test_file_config.py
@@ -16,6 +16,8 @@ from pydantic import ValidationError
 
 from cachekit.backends.file.config import FileBackendConfig
 
+pytestmark = pytest.mark.unit
+
 
 class TestFileBackendConfigDefaults:
     """Test default configuration values."""


### PR DESCRIPTION
## Summary
- Add `pytestmark = pytest.mark.unit` to `test_file_config.py`, `test_cachekitio_config.py`, `test_cachekitio_error_handler.py` for consistency with other unit backend tests
- Remove unused `monkeypatch` parameter from file backend critical test fixture
- Fix stale docstrings in critical conftest

## Test plan
- [x] All affected test files still pass
- [x] Lint and format clean