### PR TITLE
chore: gitignore AI agent configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,13 @@ coverage.json
 .wrangler/
 dist-linux/
 .dist-linux-build/
+
+# AI agent configs (never commit to public repos)
+CLAUDE.md
+AGENTS.md
+.claude/
+.caliber/
+CALIBER_LEARNINGS.md
+.cursor/
+.cursorrules
+.github/copilot-instructions.md


### PR DESCRIPTION
Prevents CLAUDE.md, .claude/, .caliber/, and other AI agent config files from being committed to the public repository. Safety fix — these are local development aids.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gitignore configuration to prevent committing AI agent and development tool configuration files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->