### PR TITLE
fix: use local> preset ref for private renovate-config repo

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>cachekit-io/renovate-config"]
+  "extends": ["local>cachekit-io/renovate-config"]
 }


### PR DESCRIPTION
Renovate can't resolve `github>` refs to private repos. Switch to `local>` which uses the GitHub App token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate dependency management configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->