### PR TITLE
ci: fix attestation and security-deep workflow failures

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -134,7 +134,7 @@ jobs:
   attest:
     name: Attest Build Provenance and SBOM
     needs: [release-please, build-wheels, build-sdist]
-    if: needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -160,7 +160,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ needs.release-please.outputs.tag_name || github.event.inputs.release_tag }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -168,7 +168,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup toolchain install stable --profile minimal
 
       - name: Generate Python SBOM
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -59,8 +59,9 @@ jobs:
     steps:
       - name: Validate release_tag
         id: validate
+        env:
+          TAG: ${{ github.event.inputs.release_tag }}
         run: |
-          TAG="${{ github.event.inputs.release_tag }}"
           if [ -z "$TAG" ]; then
             echo "::error::force_release requires release_tag (e.g., v0.6.0)"
             exit 1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,11 +49,24 @@ jobs:
           config-file: release-please-config.json
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
 
+  validate-inputs:
+    name: Validate Release Inputs
+    needs: release-please
+    if: github.event.inputs.force_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require release_tag for force_release
+        run: |
+          if [ -z "${{ github.event.inputs.release_tag }}" ]; then
+            echo "::error::force_release requires release_tag to be set (e.g., cachekit-v0.6.0)"
+            exit 1
+          fi
+
   build-wheels:
     name: Build wheels (${{ matrix.target }})
-    needs: release-please
-    # Run if: release-please created a release OR manual dispatch with force_release
-    if: needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true'
+    needs: [release-please, validate-inputs]
+    # Run if: release-please created a release OR manual dispatch with force_release (validate-inputs ensures release_tag is set)
+    if: ${{ !failure() && !cancelled() && (needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true') }}
     strategy:
       matrix:
         include:
@@ -112,8 +125,8 @@ jobs:
 
   build-sdist:
     name: Build source distribution
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true'
+    needs: [release-please, validate-inputs]
+    if: ${{ !failure() && !cancelled() && (needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -204,6 +217,7 @@ jobs:
   publish:
     name: Publish to PyPI
     needs: [release-please, build-wheels, build-sdist, attest]
+    if: ${{ !failure() && !cancelled() && (needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true') }}
     runs-on: ubuntu-latest
     environment: release
     permissions:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -69,7 +69,7 @@ jobs:
             echo "::error::release_tag must match vX.Y.Z (got: $TAG)"
             exit 1
           fi
-          if ! git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+          if ! git ls-remote --tags "https://github.com/${{ github.repository }}.git" "refs/tags/$TAG" | grep -q .; then
             echo "::error::tag $TAG does not exist on remote"
             exit 1
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ on:
           - 'false'
           - 'true'
       release_tag:
-        description: 'Tag to release (e.g., cachekit-v0.1.0)'
+        description: 'Tag to release (e.g., v0.6.0)'
         required: false
         type: string
 
@@ -54,13 +54,26 @@ jobs:
     needs: release-please
     if: github.event.inputs.force_release == 'true'
     runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.validate.outputs.release_tag }}
     steps:
-      - name: Require release_tag for force_release
+      - name: Validate release_tag
+        id: validate
         run: |
-          if [ -z "${{ github.event.inputs.release_tag }}" ]; then
-            echo "::error::force_release requires release_tag to be set (e.g., cachekit-v0.6.0)"
+          TAG="${{ github.event.inputs.release_tag }}"
+          if [ -z "$TAG" ]; then
+            echo "::error::force_release requires release_tag (e.g., v0.6.0)"
             exit 1
           fi
+          if ! echo "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::release_tag must match vX.Y.Z (got: $TAG)"
+            exit 1
+          fi
+          if ! git ls-remote --tags origin "refs/tags/$TAG" | grep -q .; then
+            echo "::error::tag $TAG does not exist on remote"
+            exit 1
+          fi
+          echo "release_tag=$TAG" >> "$GITHUB_OUTPUT"
 
   build-wheels:
     name: Build wheels (${{ matrix.target }})
@@ -96,7 +109,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Use release-please tag or manual input tag
-          ref: ${{ needs.release-please.outputs.tag_name || github.event.inputs.release_tag }}
+          ref: ${{ needs.release-please.outputs.tag_name || needs.validate-inputs.outputs.release_tag }}
 
       # Python setup required for native builds (macOS/Windows) to discover interpreters
       # Linux uses Docker containers which have Python pre-installed
@@ -131,7 +144,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ needs.release-please.outputs.tag_name || github.event.inputs.release_tag }}
+          ref: ${{ needs.release-please.outputs.tag_name || needs.validate-inputs.outputs.release_tag }}
 
       - uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1
         with:
@@ -146,7 +159,7 @@ jobs:
 
   attest:
     name: Attest Build Provenance and SBOM
-    needs: [release-please, build-wheels, build-sdist]
+    needs: [release-please, validate-inputs, build-wheels, build-sdist]
     if: needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -173,7 +186,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ needs.release-please.outputs.tag_name || github.event.inputs.release_tag }}
+          ref: ${{ needs.release-please.outputs.tag_name || needs.validate-inputs.outputs.release_tag }}
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -22,7 +22,10 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Ensure stable toolchain
-      run: rustup toolchain install stable
+      run: |
+        # Runner image ships stable; only install if missing.
+        # Full `toolchain install` can hit EXDEV in containers (rust-lang/rustup#1239).
+        rustup toolchain list | grep -q stable || rustup toolchain install stable
 
     - name: Install Kani
       run: |


### PR DESCRIPTION
## Summary

- Replace unpinned `dtolnay/rust-toolchain@stable` with bare `rustup` in attestation job — fixes SHA-pinning enforcement that blocked the 0.6.0 release
- Make Kani's `rustup toolchain install` conditional (skip if stable already present) — avoids `EXDEV` cross-device link error in containers ([rust-lang/rustup#1239](https://github.com/rust-lang/rustup/issues/1239))

## Test plan

- [ ] Merge and re-run release workflow for v0.6.0
- [ ] Verify attestation job passes
- [ ] Next nightly security-deep run passes Kani

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI: Added an inputs validation step for manual forced releases that enforces and exports a validated release tag; build, attest, and packaging stages now wait for validation and skip on failure or cancellation.
  * CI: Attest runs for forced releases and uses the validated tag for checkout.
  * CI: Publish runs only after successful, non-cancelled builds and when a release is created or a forced release is validated.

* **Rust setup**
  * Toolchain setup now uses rustup with a minimal profile; verification installs the stable toolchain only if missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->