### PR TITLE
ci: harden release workflow and fix flaky test

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -187,11 +187,7 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-<<<<<<< HEAD
           ref: ${{ needs.release-please.outputs.tag_name || needs.validate-inputs.outputs.release_tag }}
-=======
-          ref: ${{ needs.release-please.outputs.tag_name || github.event.inputs.release_tag }}
->>>>>>> 2ba2354 (ci: allow force_release to flow through attest and publish jobs)
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -187,7 +187,11 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+<<<<<<< HEAD
           ref: ${{ needs.release-please.outputs.tag_name || needs.validate-inputs.outputs.release_tag }}
+=======
+          ref: ${{ needs.release-please.outputs.tag_name || github.event.inputs.release_tag }}
+>>>>>>> 2ba2354 (ci: allow force_release to flow through attest and publish jobs)
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5

--- a/tests/unit/test_load_control.py
+++ b/tests/unit/test_load_control.py
@@ -144,41 +144,48 @@ class TestBackpressureController:
         assert controller.queue_depth == 0
 
     def test_concurrent_operations(self):
-        """Test controller under high concurrency."""
-        controller = BackpressureController(max_concurrent=5, queue_size=10, timeout=0.1)
+        """Test controller under high concurrency.
+
+        Uses a Barrier to force all threads to compete simultaneously,
+        and work duration >> timeout so permits can't be recycled.
+        Capacity = max_concurrent(2) + queue_size(3) = 5, so 15 of 20
+        threads must be rejected — no timing sensitivity.
+        """
+        controller = BackpressureController(max_concurrent=2, queue_size=3, timeout=0.01)
 
         results = []
         exceptions = []
+        barrier = threading.Barrier(20, timeout=5)
 
         def worker(worker_id):
             from cachekit.backends.errors import BackendError
 
             try:
+                barrier.wait()  # All threads launch simultaneously
                 with controller.acquire():
-                    time.sleep(0.05)  # Simulate work
+                    time.sleep(0.2)  # Hold permit far longer than timeout
                     results.append(worker_id)
             except BackendError as e:
                 exceptions.append((worker_id, str(e)))
+            except threading.BrokenBarrierError:
+                exceptions.append((worker_id, "barrier broken"))
 
-        # Launch many concurrent workers
         threads = []
-        for i in range(20):  # More than max_concurrent + queue_size
+        for i in range(20):
             t = threading.Thread(target=worker, args=(i,))
             threads.append(t)
             t.start()
 
-        # Wait for all threads
         for t in threads:
             t.join()
 
-        # Some should succeed, some should be rejected
         assert len(results) > 0, "Some operations should succeed"
         assert len(exceptions) > 0, "Some operations should be rejected"
         assert len(results) + len(exceptions) == 20
 
         # Verify final state is clean
         assert controller.queue_depth == 0
-        assert controller._semaphore._value == 5  # Back to max_concurrent
+        assert controller._semaphore._value == 2  # Back to max_concurrent
 
     def test_metrics_tracking(self):
         """Test that metrics are properly tracked."""


### PR DESCRIPTION
## Summary

- Add `validate-inputs` job that rejects `force_release` without a valid semver tag (`vX.Y.Z`) and verifies the tag exists on the remote
- Route validated tag through job output instead of raw `github.event.inputs` (prevents script injection)
- Add explicit `if` guard on `publish` job (defense in depth)
- Wire `force_release` gate through `attest` and `publish` jobs so manual re-releases complete end-to-end
- Fix flaky `test_concurrent_operations` — use `threading.Barrier` for deterministic contention instead of timing-dependent `time.sleep`

## Test plan

- [ ] CI passes on this PR (especially Python 3.13)
- [ ] After merge, re-run 0.6.0 release: `gh workflow run release-please.yml --ref main -f force_release=true -f release_tag=v0.6.0`
- [ ] Verify `force_release=true` without `release_tag` fails fast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal test improvements with no user-facing changes. Test reliability enhancements were made to improve code quality assurance processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->