### PR TITLE
test: assert expired key directly now that time-machine controls clock

### DIFF
--- a/tests/critical/test_file_backend_critical.py
+++ b/tests/critical/test_file_backend_critical.py
@@ -66,10 +66,7 @@ def test_ttl_enforced(backend):
 
         # Permanent still exists, temporary is gone
         assert backend.get("permanent") == b"stays"
-        # Skip reading expired key directly due to file handle bug in FileBackend
-        # Instead verify by setting a new key (proves cleanup didn't affect backend)
-        backend.set("new_key", b"new_value")
-        assert backend.get("new_key") == b"new_value"
+        assert backend.get("temporary") is None
 
 
 @pytest.mark.critical


### PR DESCRIPTION
## Summary

- Remove workaround in `test_ttl_enforced` that avoided reading expired keys directly due to a file handle bug in FileBackend
- With `time-machine` controlling the clock (added in #94), `backend.get("temporary")` correctly returns `None` after advancing past TTL
- Subsumes the fix from stale PR #95 (CodeRabbit auto-fix targeting a deleted branch)

## Test plan

- [x] `test_ttl_enforced` passes locally (verified 5/5 runs)
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

No user-facing changes in this release. This update includes internal test improvements to verify existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->