### PR TITLE
chore: strip redundant setup-python from codeql (baked into runner)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,13 +52,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # Python setup for accurate analysis
-      - name: Set up Python
-        if: matrix.language == 'python'
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.12"
-
       - name: Install Python dependencies
         if: matrix.language == 'python'
         run: |


### PR DESCRIPTION
Runner v0.3.0 has Python 3.9-3.14 baked in. No need for setup-python on cachekit self-hosted runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified the CodeQL CI workflow for Python analysis so it proceeds directly to installing dependencies and running the scan.
  * Removed the explicit Python setup step from the Python analysis path, streamlining the job flow and reducing workflow steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cachekit-io/cachekit-py/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->