### PR TITLE
test: eliminate flaky time.sleep() tests with deterministic coordination

### DIFF
--- a/tests/critical/conftest.py
+++ b/tests/critical/conftest.py
@@ -12,6 +12,7 @@ def pytest_runtest_setup(item):
         or "memcached_backend" in item.nodeid
         or "secure_env_fallback" in item.nodeid
         or "local_cache_works" in item.nodeid
+        or "backpressure_load_control" in item.nodeid
     )
     if skip_redis:
         # Remove autouse redis fixtures for tests that don't need Redis

--- a/tests/critical/test_backpressure_load_control.py
+++ b/tests/critical/test_backpressure_load_control.py
@@ -16,6 +16,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from cachekit.reliability.load_control import BackpressureController
+from tests.utils.timing_helper import ThreadGate, TimingHelper
 
 pytestmark = pytest.mark.critical
 
@@ -38,7 +39,7 @@ class TestBackpressureLoadControl:
                     active_count["value"] += 1
                     max_observed["value"] = max(max_observed["value"], active_count["value"])
 
-                time.sleep(0.1)  # Hold permit for 100ms
+                time.sleep(0.1)  # Hold permit for 100ms (simulates real work)
 
                 with lock:
                     active_count["value"] -= 1
@@ -61,14 +62,17 @@ class TestBackpressureLoadControl:
             timeout=10.0,  # Long timeout (we won't wait)
         )
 
+        gate = ThreadGate()
+
         # Block the single execution slot
-        lock = threading.Lock()
-        lock.acquire()  # Held until we release it
+        execution_lock = threading.Lock()
+        execution_lock.acquire()  # Held until we release it
 
         def blocking_operation():
             """Operation that blocks until lock is released."""
             with controller.acquire():
-                with lock:  # This will block
+                gate.signal("acquired")
+                with execution_lock:  # This will block
                     pass
 
         def quick_operation():
@@ -79,7 +83,7 @@ class TestBackpressureLoadControl:
         # Start the blocking operation in a thread
         blocking_thread = threading.Thread(target=blocking_operation)
         blocking_thread.start()
-        time.sleep(0.05)  # Let it acquire the execution permit
+        gate.wait("acquired")
 
         # Now the execution slot is occupied, queue should start filling
         # Try to launch more operations than queue_size
@@ -103,7 +107,7 @@ class TestBackpressureLoadControl:
             t.join(timeout=1.0)
 
         # Release the blocking operation
-        lock.release()
+        execution_lock.release()
         blocking_thread.join(timeout=1.0)
 
         # Should have rejected the operations beyond queue capacity
@@ -117,19 +121,22 @@ class TestBackpressureLoadControl:
             timeout=0.01,  # Very short timeout for fast fail
         )
 
+        gate = ThreadGate()
+
         # Occupy the execution slot
         execution_lock = threading.Lock()
         execution_lock.acquire()
 
         def blocking_op():
             with controller.acquire():
+                gate.signal("acquired")
                 with execution_lock:
                     pass
 
         # Start blocking operation
         thread = threading.Thread(target=blocking_op)
         thread.start()
-        time.sleep(0.05)  # Let it acquire
+        gate.wait("acquired")
 
         # Now queue is full and execution is blocked
         # New request should fail fast
@@ -176,7 +183,12 @@ class TestBackpressureLoadControl:
         for t in threads:
             t.start()
 
-        time.sleep(0.1)  # Let them queue up
+        # Wait for threads to queue up (deterministic polling)
+        TimingHelper.wait_for_condition(
+            lambda: controller.queue_depth > 0,
+            timeout=2.0,
+            message="Should have queued requests",
+        )
 
         # Queue depth should be >0 (threads are waiting)
         current_depth = controller.queue_depth
@@ -199,18 +211,21 @@ class TestBackpressureLoadControl:
             timeout=0.01,
         )
 
+        gate = ThreadGate()
+
         # Block the execution slot
         execution_lock = threading.Lock()
         execution_lock.acquire()
 
         def blocking_op():
             with controller.acquire():
+                gate.signal("acquired")
                 with execution_lock:
                     pass
 
         thread = threading.Thread(target=blocking_op)
         thread.start()
-        time.sleep(0.05)
+        gate.wait("acquired")
 
         initial_rejected = controller.rejected_count
 
@@ -326,13 +341,15 @@ class TestBackpressureLoadControl:
         for t in threads:
             t.start()
 
-        time.sleep(0.1)  # Let them queue
+        # Wait for threads to queue (deterministic polling)
+        TimingHelper.wait_for_condition(
+            lambda: controller.queue_depth > 0,
+            timeout=2.0,
+            message="Should have queued requests",
+        )
 
         stats = controller.get_stats()
         assert stats["queue_depth"] > 0, "Should show queued requests"
-        # Health should be False if queue_depth >= 80% of queue_size
-        # 90 operations, 10 concurrent = 80 in queue -> 80% threshold
-        # This might be True or False depending on exact timing
 
         # Cleanup
         execution_lock.release()
@@ -402,18 +419,21 @@ class TestBackpressureLoadControl:
         """CRITICAL: reset_stats() properly clears monitoring counters."""
         controller = BackpressureController(max_concurrent=1, queue_size=1, timeout=0.01)
 
+        gate = ThreadGate()
+
         # Block execution
         execution_lock = threading.Lock()
         execution_lock.acquire()
 
         def blocking_op():
             with controller.acquire():
+                gate.signal("acquired")
                 with execution_lock:
                     pass
 
         thread = threading.Thread(target=blocking_op)
         thread.start()
-        time.sleep(0.05)
+        gate.wait("acquired")
 
         # Generate rejections
         from cachekit.backends.errors import BackendError

--- a/tests/unit/test_l1_swr.py
+++ b/tests/unit/test_l1_swr.py
@@ -1,10 +1,9 @@
 """Unit tests for L1Cache stale-while-revalidate (SWR) functionality."""
 
 import threading
-import time
-from unittest.mock import patch
 
 import pytest
+import time_machine
 
 from cachekit.config.nested import L1CacheConfig
 from cachekit.l1_cache import L1Cache
@@ -41,14 +40,13 @@ class TestL1CacheSWR:
         value = b"test_value"
         ttl = 100.0
 
-        # Mock time to simulate staleness
-        with patch("time.time") as mock_time:
+        with time_machine.travel(0, tick=False) as traveller:
             # Time at put
-            mock_time.return_value = 1000.0
+            traveller.move_to(1000.0)
             cache.put(key, value, redis_ttl=ttl)
 
             # Time at get (60s later, past threshold of ~50s even with jitter)
-            mock_time.return_value = 1060.0
+            traveller.move_to(1060.0)
             hit, val, needs_refresh, version = cache.get_with_swr(key, ttl)
 
             assert hit is True
@@ -65,13 +63,13 @@ class TestL1CacheSWR:
         value = b"test_value"
         ttl = 100.0
 
-        with patch("time.time") as mock_time:
+        with time_machine.travel(0, tick=False) as traveller:
             # Put at time 1000
-            mock_time.return_value = 1000.0
+            traveller.move_to(1000.0)
             cache.put(key, value, redis_ttl=ttl)
 
             # First get at 1060 (triggers refresh)
-            mock_time.return_value = 1060.0
+            traveller.move_to(1060.0)
             hit1, val1, needs_refresh1, version1 = cache.get_with_swr(key, ttl)
             assert needs_refresh1 is True
 
@@ -90,20 +88,20 @@ class TestL1CacheSWR:
         new_value = b"new_value"
         ttl = 100.0
 
-        with patch("time.time") as mock_time:
+        with time_machine.travel(0, tick=False) as traveller:
             # Put old value
-            mock_time.return_value = 1000.0
+            traveller.move_to(1000.0)
             cache.put(key, old_value, redis_ttl=ttl)
 
             # Trigger refresh
-            mock_time.return_value = 1060.0
+            traveller.move_to(1060.0)
             hit, val, needs_refresh, version = cache.get_with_swr(key, ttl)
             assert needs_refresh is True
             assert version == 0
 
             # Complete refresh
-            mock_time.return_value = 1065.0
-            success = cache.complete_refresh(key, version, new_value, mock_time.return_value)
+            traveller.move_to(1065.0)
+            success = cache.complete_refresh(key, version, new_value, 1065.0)
             assert success is True
 
             # Verify new value is cached
@@ -129,14 +127,14 @@ class TestL1CacheSWR:
             cache.clear()
             test_key = f"{key}_{i}"
 
-            with patch("time.time") as mock_time:
+            with time_machine.travel(0, tick=False) as traveller:
                 # Put at time 1000
-                mock_time.return_value = 1000.0
+                traveller.move_to(1000.0)
                 cache.put(test_key, value, redis_ttl=ttl)
 
                 # Test at different elapsed times to find threshold
                 for elapsed in range(40, 61):  # 40-60s (around 50s ±10%)
-                    mock_time.return_value = 1000.0 + elapsed
+                    traveller.move_to(1000.0 + elapsed)
                     hit, val, needs_refresh, version = cache.get_with_swr(test_key, ttl)
 
                     if needs_refresh:
@@ -164,13 +162,13 @@ class TestL1CacheSWR:
         value = b"test_value"
         ttl = 100.0
 
-        with patch("time.time") as mock_time:
+        with time_machine.travel(0, tick=False) as traveller:
             # Put at time 1000
-            mock_time.return_value = 1000.0
+            traveller.move_to(1000.0)
             cache.put(key, value, redis_ttl=ttl)
 
             # Trigger refresh
-            mock_time.return_value = 1060.0
+            traveller.move_to(1060.0)
             hit, val, needs_refresh, version = cache.get_with_swr(key, ttl)
             assert needs_refresh is True
 
@@ -186,9 +184,10 @@ class TestL1CacheSWR:
         """Test that version mismatch prevents stale refresh under concurrent invalidation.
 
         CRITICAL RACE CONDITION TEST:
-        Thread 1: Triggers SWR refresh, sleeps 100ms, attempts complete_refresh()
-        Thread 2: Invalidates key after 50ms
-        Expected: complete_refresh() returns False (version mismatch), entry does NOT exist
+        Uses threading.Event for deterministic ordering (no sleep-based timing):
+        1. Refresher triggers SWR refresh, signals ready, waits for invalidation
+        2. Invalidator waits for ready signal, invalidates key, signals done
+        3. Refresher attempts complete_refresh() — must see version mismatch
         """
         config = L1CacheConfig(swr_enabled=True, swr_threshold_ratio=0.5)
         cache = L1Cache(max_memory_mb=10, config=config)
@@ -198,54 +197,64 @@ class TestL1CacheSWR:
         new_value = b"new_value"
         ttl = 100.0
 
+        # Deterministic synchronization — no timing assumptions
+        refresh_triggered = threading.Event()
+        invalidation_done = threading.Event()
+
         # Shared state
         refresh_result = [None]
         thread_errors = []
 
         def refresher_thread():
-            """Thread that triggers refresh and attempts to complete it after delay."""
+            """Thread that triggers refresh, waits for invalidation, then completes."""
             try:
-                with patch("time.time") as mock_time:
-                    # Trigger refresh
-                    mock_time.return_value = 1060.0
-                    hit, val, needs_refresh, version = cache.get_with_swr(key, ttl)
+                # Trigger refresh (time is frozen at 1060.0 by time-machine)
+                hit, val, needs_refresh, version = cache.get_with_swr(key, ttl)
 
-                    if needs_refresh:
-                        # Simulate slow refresh (100ms)
-                        time.sleep(0.1)
+                if needs_refresh:
+                    # Signal: refresh is in progress, invalidator can proceed
+                    refresh_triggered.set()
 
-                        # Try to complete refresh
-                        mock_time.return_value = 1065.0
-                        success = cache.complete_refresh(key, version, new_value, mock_time.return_value)
-                        refresh_result[0] = success
+                    # Wait for invalidation to complete before attempting refresh
+                    invalidation_done.wait(timeout=2.0)
+
+                    # Try to complete refresh — should fail (version mismatch)
+                    success = cache.complete_refresh(key, version, new_value, 1065.0)
+                    refresh_result[0] = success
             except Exception as e:
                 thread_errors.append(e)
 
         def invalidator_thread():
-            """Thread that invalidates key during refresh."""
+            """Thread that invalidates key after refresh is triggered."""
             try:
-                # Wait 50ms (midway through refresh)
-                time.sleep(0.05)
+                # Wait until refresher has triggered SWR
+                refresh_triggered.wait(timeout=2.0)
 
-                # Invalidate key
+                # Invalidate key (increments version)
                 cache.invalidate_by_key(key)
+
+                # Signal: invalidation complete, refresher can proceed
+                invalidation_done.set()
             except Exception as e:
                 thread_errors.append(e)
 
-        # Setup: Put initial value
-        with patch("time.time") as mock_time:
-            mock_time.return_value = 1000.0
+        # Setup: Put initial value and advance clock past SWR threshold
+        with time_machine.travel(0, tick=False) as traveller:
+            traveller.move_to(1000.0)
             cache.put(key, old_value, redis_ttl=ttl)
 
-        # Start concurrent threads
-        t1 = threading.Thread(target=refresher_thread)
-        t2 = threading.Thread(target=invalidator_thread)
+            # Advance past SWR threshold so get_with_swr triggers refresh
+            traveller.move_to(1060.0)
 
-        t1.start()
-        t2.start()
+            # Start concurrent threads
+            t1 = threading.Thread(target=refresher_thread)
+            t2 = threading.Thread(target=invalidator_thread)
 
-        t1.join(timeout=1.0)
-        t2.join(timeout=1.0)
+            t1.start()
+            t2.start()
+
+            t1.join(timeout=5.0)
+            t2.join(timeout=5.0)
 
         # Verify no thread errors
         assert len(thread_errors) == 0, f"Thread errors occurred: {thread_errors}"
@@ -267,13 +276,13 @@ class TestL1CacheSWR:
         value = b"test_value"
         ttl = 100.0
 
-        with patch("time.time") as mock_time:
+        with time_machine.travel(0, tick=False) as traveller:
             # Put at time 1000
-            mock_time.return_value = 1000.0
+            traveller.move_to(1000.0)
             cache.put(key, value, redis_ttl=ttl)
 
             # Get at 1060 (way past threshold)
-            mock_time.return_value = 1060.0
+            traveller.move_to(1060.0)
             hit, val, needs_refresh, version = cache.get_with_swr(key, ttl)
 
             assert hit is True
@@ -289,13 +298,13 @@ class TestL1CacheSWR:
         value = b"test_value"
         ttl = 100.0
 
-        with patch("time.time") as mock_time:
+        with time_machine.travel(0, tick=False) as traveller:
             # Put at time 1000
-            mock_time.return_value = 1000.0
+            traveller.move_to(1000.0)
             cache.put(key, value, redis_ttl=ttl)
 
             # Get at 1101 (past expiry)
-            mock_time.return_value = 1101.0
+            traveller.move_to(1101.0)
             hit, val, needs_refresh, version = cache.get_with_swr(key, ttl)
 
             assert hit is False
@@ -312,13 +321,13 @@ class TestL1CacheSWR:
         new_value = b"new_value"
         ttl = 100.0
 
-        with patch("time.time") as mock_time:
+        with time_machine.travel(0, tick=False) as traveller:
             # Put entry
-            mock_time.return_value = 1000.0
+            traveller.move_to(1000.0)
             cache.put(key, value, redis_ttl=ttl)
 
             # Trigger refresh
-            mock_time.return_value = 1060.0
+            traveller.move_to(1060.0)
             hit, val, needs_refresh, version = cache.get_with_swr(key, ttl)
             assert needs_refresh is True
 
@@ -326,8 +335,8 @@ class TestL1CacheSWR:
             cache.invalidate_by_key(key)
 
             # Try to complete refresh (entry no longer exists)
-            mock_time.return_value = 1065.0
-            success = cache.complete_refresh(key, version, new_value, mock_time.return_value)
+            traveller.move_to(1065.0)
+            success = cache.complete_refresh(key, version, new_value, 1065.0)
 
             # Should return False (entry was evicted, even though version might match)
             # NOTE: Current implementation returns False for evicted entries

--- a/tests/unit/test_load_control.py
+++ b/tests/unit/test_load_control.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from cachekit.reliability.load_control import BackpressureController
+from tests.utils.timing_helper import ThreadGate, TimingHelper
 
 
 class TestBackpressureController:
@@ -51,17 +52,19 @@ class TestBackpressureController:
         """Test that requests are rejected when queue is full."""
         controller = BackpressureController(max_concurrent=1, queue_size=2, timeout=0.1)
 
+        gate = ThreadGate()
+        release = threading.Event()
+
         # Fill the semaphore with a long-running operation
         def blocking_operation():
             with controller.acquire():
-                time.sleep(0.2)  # Hold the permit
+                gate.signal("acquired")
+                release.wait(timeout=5.0)
 
         # Start background thread to hold the semaphore
         thread = threading.Thread(target=blocking_operation)
         thread.start()
-
-        # Give time for thread to acquire semaphore
-        time.sleep(0.05)
+        gate.wait("acquired")
 
         # These requests should be able to join the queue
         exceptions = []
@@ -82,7 +85,12 @@ class TestBackpressureController:
             queue_threads.append(t)
             t.start()
 
-        time.sleep(0.05)  # Let them enter queue
+        # Wait for queue to fill (threads are waiting on the semaphore)
+        TimingHelper.wait_for_condition(
+            lambda: controller.queue_depth >= 2,
+            timeout=2.0,
+            message="Queue should have 2 entries",
+        )
 
         # This request should be rejected (queue full)
         from cachekit.backends.errors import BackendError
@@ -95,6 +103,7 @@ class TestBackpressureController:
         assert controller.rejected_count >= 1
 
         # Clean up
+        release.set()
         thread.join()
         for t in queue_threads:
             t.join()
@@ -103,16 +112,18 @@ class TestBackpressureController:
         """Test that requests timeout when unable to acquire semaphore."""
         controller = BackpressureController(max_concurrent=1, timeout=0.05)
 
+        gate = ThreadGate()
+        release = threading.Event()
+
         # Hold the semaphore with a blocking operation
         def blocking_operation():
             with controller.acquire():
-                time.sleep(0.2)
+                gate.signal("acquired")
+                release.wait(timeout=5.0)
 
         thread = threading.Thread(target=blocking_operation)
         thread.start()
-
-        # Give time for thread to acquire semaphore
-        time.sleep(0.02)
+        gate.wait("acquired")
 
         # This should timeout
         from cachekit.backends.errors import BackendError
@@ -125,6 +136,7 @@ class TestBackpressureController:
         assert controller.rejected_count == 1
 
         # Clean up
+        release.set()
         thread.join()
 
     def test_context_manager_exception_handling(self):
@@ -333,14 +345,18 @@ class TestBackpressureController:
         """Test behavior with very small timeouts."""
         controller = BackpressureController(max_concurrent=1, timeout=0.001)
 
+        gate = ThreadGate()
+        release = threading.Event()
+
         # Hold the semaphore
         def blocking_operation():
             with controller.acquire():
-                time.sleep(0.1)
+                gate.signal("acquired")
+                release.wait(timeout=5.0)
 
         thread = threading.Thread(target=blocking_operation)
         thread.start()
-        time.sleep(0.01)  # Ensure semaphore is held
+        gate.wait("acquired")
 
         # This should timeout very quickly
         from cachekit.backends.errors import BackendError
@@ -353,4 +369,5 @@ class TestBackpressureController:
         elapsed = time.time() - start_time
         assert elapsed < 0.2  # Should timeout quickly (generous for CI jitter)
 
+        release.set()
         thread.join()

--- a/tests/unit/test_metrics_collection.py
+++ b/tests/unit/test_metrics_collection.py
@@ -1,7 +1,6 @@
 """Unit tests for metrics collection infrastructure."""
 
 import threading
-import time
 from unittest.mock import patch
 
 from cachekit.reliability.metrics_collection import (
@@ -71,8 +70,7 @@ class TestAsyncMetricsCollector:
         collector.record_counter("test_counter", {"label1": "value1"}, 2.0)
         collector.record_counter("test_counter", {"label1": "value2"}, 1.0)
 
-        # Allow time for processing
-        time.sleep(0.1)
+        collector.flush()
 
         stats = collector.get_stats()
         assert stats["processed_count"] >= 2
@@ -88,8 +86,7 @@ class TestAsyncMetricsCollector:
         collector.record_histogram("test_histogram", 0.025, {"operation": "get"})
         collector.record_histogram("test_histogram", 0.15, {"operation": "set"})
 
-        # Allow time for processing
-        time.sleep(0.1)
+        collector.flush()
 
         stats = collector.get_stats()
         assert stats["processed_count"] >= 2
@@ -104,8 +101,7 @@ class TestAsyncMetricsCollector:
         collector.record_gauge("test_gauge", 0.75, {"type": "utilization"})
         collector.record_gauge("test_gauge", 0.85, {"type": "utilization"})
 
-        # Allow time for processing
-        time.sleep(0.1)
+        collector.flush()
 
         stats = collector.get_stats()
         assert stats["processed_count"] >= 2
@@ -121,8 +117,7 @@ class TestAsyncMetricsCollector:
         for i in range(20):
             collector.record_counter("overflow_test", {"id": str(i)})
 
-        # Allow time for processing
-        time.sleep(0.2)
+        collector.flush()
 
         stats = collector.get_stats()
         # Some metrics should have been dropped
@@ -202,8 +197,7 @@ class TestAsyncMetricsCollector:
         for thread in threads:
             thread.join()
 
-        # Allow time for processing
-        time.sleep(0.2)
+        collector.flush()
 
         stats = collector.get_stats()
         # Should have processed 50 metrics (5 threads × 10 metrics each)
@@ -223,8 +217,7 @@ class TestAsyncMetricsCollector:
         # Record a valid metric after the malformed one
         collector.record_counter("valid_metric", {"test": "value"})
 
-        # Allow time for processing
-        time.sleep(0.2)
+        collector.flush()
 
         # Worker should still be alive despite the error
         assert collector._worker_thread.is_alive()
@@ -274,8 +267,7 @@ class TestMetricsIntegration:
         # Record a cache operation metric
         collector.record_counter("redis_cache_operations_total", {"operation": "get", "status": "hit"}, 1.0)
 
-        # Allow time for processing
-        time.sleep(0.1)
+        collector.flush()
 
         # Should have called the Prometheus metric
         mock_counter.labels.assert_called_with(operation="get", status="hit")
@@ -291,8 +283,7 @@ class TestMetricsIntegration:
         # Record a latency metric
         collector.record_histogram("redis_cache_operation_duration_seconds", 0.025, {"operation": "set"})
 
-        # Allow time for processing
-        time.sleep(0.1)
+        collector.flush()
 
         # Should have called the Prometheus metric
         mock_histogram.labels.assert_called_with(operation="set")
@@ -308,8 +299,7 @@ class TestMetricsIntegration:
         # Record a circuit breaker state metric
         collector.record_gauge("redis_circuit_breaker_state", 1.0, {"namespace": "test"})
 
-        # Allow time for processing
-        time.sleep(0.1)
+        collector.flush()
 
         # Should have called the Prometheus metric
         mock_gauge.labels.assert_called_with(namespace="test")
@@ -325,8 +315,7 @@ class TestMetricsIntegration:
             # Record a metric with unknown name
             collector.record_counter("unknown_metric_name", {"test": "value"}, 1.0)
 
-            # Allow time for processing
-            time.sleep(0.1)
+            collector.flush()
 
             # Should log debug message about unknown metric
             mock_logger.debug.assert_called()

--- a/tests/utils/timing_helper.py
+++ b/tests/utils/timing_helper.py
@@ -1,7 +1,8 @@
-"""Timing utilities for deterministic test polling (no flakiness)."""
+"""Timing utilities for deterministic test coordination (no flakiness)."""
 
 from __future__ import annotations
 
+import threading
 import time
 from typing import Callable
 
@@ -13,7 +14,7 @@ class TimingHelper:
     def wait_for_condition(
         condition_func: Callable[[], bool],
         timeout: float = 5.0,
-        interval: float = 0.1,
+        interval: float = 0.01,
         message: str = "Condition not met",
     ) -> None:
         """Wait for condition with timeout (deterministic, no flakiness).
@@ -21,7 +22,7 @@ class TimingHelper:
         Args:
             condition_func: Function that returns True when condition is met.
             timeout: Maximum time to wait in seconds (default: 5.0).
-            interval: Time to sleep between checks in seconds (default: 0.1).
+            interval: Time to sleep between checks in seconds (default: 0.01).
             message: Error message to raise on timeout.
 
         Raises:
@@ -33,3 +34,57 @@ class TimingHelper:
                 return
             time.sleep(interval)
         raise TimeoutError(f"{message} after {timeout}s")
+
+
+class ThreadGate:
+    """Named synchronization points for deterministic thread coordination.
+
+    Replaces flaky ``time.sleep()`` ordering with explicit signals between
+    threads.  Each gate is a named ``threading.Event`` created on first use.
+
+    Example::
+
+        gate = ThreadGate()
+
+        def worker():
+            with controller.acquire():
+                gate.signal("acquired")   # tell main thread we hold the permit
+                with blocking_lock:       # block until main thread releases
+                    pass
+
+        thread = threading.Thread(target=worker)
+        thread.start()
+        gate.wait("acquired")             # deterministic — no sleep needed
+
+    Args:
+        timeout: Default timeout for all ``wait()`` calls (seconds).
+    """
+
+    def __init__(self, timeout: float = 5.0) -> None:
+        self._events: dict[str, threading.Event] = {}
+        self._lock = threading.Lock()
+        self._timeout = timeout
+
+    def _get_event(self, name: str) -> threading.Event:
+        with self._lock:
+            if name not in self._events:
+                self._events[name] = threading.Event()
+            return self._events[name]
+
+    def signal(self, name: str) -> None:
+        """Signal that a named checkpoint has been reached."""
+        self._get_event(name).set()
+
+    def wait(self, name: str, timeout: float | None = None) -> None:
+        """Block until the named checkpoint is signaled.
+
+        Args:
+            name: Gate name to wait on.
+            timeout: Override the default timeout (seconds).
+
+        Raises:
+            TimeoutError: If the gate is not signaled within *timeout*.
+        """
+        t = timeout if timeout is not None else self._timeout
+        if not self._get_event(name).wait(timeout=t):
+            raise TimeoutError(f"ThreadGate '{name}' not signaled within {t}s")


### PR DESCRIPTION
## Summary

- Adds `ThreadGate` helper to `tests/utils/timing_helper.py` — named synchronization points for deterministic thread coordination
- Replaces 26 flaky `time.sleep()` calls across 5 test files with deterministic primitives
- Fixes `test_version_mismatch_aborts_refresh_concurrent` flake blocking release-please PR #112

### Changes by file

| File | Before | After |
|------|--------|-------|
| `tests/unit/test_l1_swr.py` | `patch("time.time")` + sleep-based thread ordering | `time-machine` + `threading.Event` |
| `tests/unit/test_load_control.py` | `time.sleep(0.05)` "let thread acquire" | `ThreadGate` + `wait_for_condition` |
| `tests/critical/test_backpressure_load_control.py` | `time.sleep(0.05)` "let it acquire" | `ThreadGate` + `wait_for_condition` |
| `tests/unit/test_metrics_collection.py` | `time.sleep(0.1)` "allow time for processing" | `collector.flush()` (existing API) |
| `tests/critical/conftest.py` | backpressure tests required Redis setup | skipped (they don't use Redis) |

### What was NOT changed

- `time.sleep` inside thread callbacks simulating real work (valid usage)
- Integration tests waiting for real Redis/memcached TTL expiry
- Performance tests measuring real elapsed time

## Test plan

- [x] All 1400 unit tests pass
- [x] All 11 critical backpressure tests pass
- [x] `test_version_mismatch_aborts_refresh_concurrent` passes 50/50 in tight loop
- [x] Ruff lint + format clean
- [x] basedpyright passes
- [ ] CI passes on this PR
- [ ] Re-run release-please PR #112 checks after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by replacing timing-dependent sleeps with deterministic thread coordination across backpressure control, cache revalidation, and metrics collection tests.
  * Reduced flakiness in critical load control and race condition testing scenarios.
  * Enhanced test infrastructure with new utilities for more robust concurrent testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cachekit-io/cachekit-py/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->