### PR TITLE
ci: fix attestation job never running on releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -161,7 +161,7 @@ jobs:
   attest:
     name: Attest Build Provenance and SBOM
     needs: [release-please, validate-inputs, build-wheels, build-sdist]
-    if: needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true'
+    if: ${{ !failure() && !cancelled() && (needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -183,7 +183,6 @@ jobs:
         uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:
           subject-path: dist/*
-        continue-on-error: true
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -230,7 +229,7 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [release-please, build-wheels, build-sdist, attest]
+    needs: [release-please, build-wheels, build-sdist]
     if: ${{ !failure() && !cancelled() && (needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true') }}
     runs-on: ubuntu-latest
     environment: release


### PR DESCRIPTION
## Summary

- Fix `attest` job's `if:` condition — was missing `!failure() && !cancelled()`, causing the job to always be skipped when `validate-inputs` was skipped (every normal push release)
- Decouple `publish` from `attest` — attestation failure should not block PyPI publishing
- Remove `continue-on-error: true` from `Attest Build Provenance` step so real failures surface

## Root Cause

The `attest` job depended on `validate-inputs` (which only runs on manual dispatch). Without the status guard in `if:`, GitHub Actions skips any job whose `needs` contains a skipped job — regardless of whether the condition itself is true.

This is why:
- v0.6.0: attest failed at "Set up job" (permissions issue, since fixed)
- v0.6.1: attest was **skipped** entirely (this bug)
- Weekly health check keeps failing (no attestations ever generated)

## Test plan

- [ ] Merge and verify next release creates attestations (trigger via `workflow_dispatch` with `force_release`)
- [ ] Verify publish still works independent of attest outcome
- [ ] Weekly attestation health check should pass after next release

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal release workflow configuration to enhance deployment reliability and efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cachekit-io/cachekit-py/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->