### PR TITLE
ci: fix miri/fuzzing EXDEV by pinning RUSTUP_HOME/CARGO_HOME to /tmp

### DIFF
--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -41,6 +41,12 @@ jobs:
     name: Extended Fuzzing (3 targets × 1h)
     runs-on: cachekit
     timeout-minutes: 200
+    env:
+      # Avoid EXDEV "cross-device link" errors when rustup stages a nightly
+      # toolchain across overlay/hostPath boundaries on the ARC runner pod
+      # (rust-lang/rustup#1239). Same pattern as fuzz-smoke.yml.
+      RUSTUP_HOME: /tmp/rustup
+      CARGO_HOME: /tmp/cargo
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -127,6 +133,12 @@ jobs:
     name: Miri Full Suite
     runs-on: cachekit
     timeout-minutes: 30
+    env:
+      # Avoid EXDEV "cross-device link" errors when rustup stages a nightly
+      # toolchain across overlay/hostPath boundaries on the ARC runner pod
+      # (rust-lang/rustup#1239). Same pattern as fuzz-smoke.yml.
+      RUSTUP_HOME: /tmp/rustup
+      CARGO_HOME: /tmp/cargo
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/security-medium.yml
+++ b/.github/workflows/security-medium.yml
@@ -61,6 +61,12 @@ jobs:
     name: Miri UB Detection (Subset)
     runs-on: cachekit
     timeout-minutes: 20
+    env:
+      # Avoid EXDEV "cross-device link" errors when rustup stages a nightly
+      # toolchain across overlay/hostPath boundaries on the ARC runner pod
+      # (rust-lang/rustup#1239). Same pattern as fuzz-smoke.yml.
+      RUSTUP_HOME: /tmp/rustup
+      CARGO_HOME: /tmp/cargo
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
## Summary

- security-medium's **miri-subset** job has been red on `main` for 12 days (since 2026-05-16, e.g. [run 26572369632](https://github.com/cachekit-io/cachekit-py/actions/runs/26572369632/job/78282553487))
- Root cause: `rustup toolchain install nightly --component miri` fails on the self-hosted `cachekit` ARC runner with `Invalid cross-device link (os error 18)` because `~/.rustup/tmp` and `~/.rustup/toolchains/...` land on different filesystem layers in the ephemeral pod (rust-lang/rustup#1239)
- security-deep's **miri-full** and **fuzzing** jobs install nightly the same way and have the same latent bug (silently broken on the nightly cron)

## Fix

Pin `RUSTUP_HOME=/tmp/rustup` and `CARGO_HOME=/tmp/cargo` for only the three affected jobs. This is the same workaround already used by `fuzz-smoke.yml` (lines 17-20) and acknowledged in a comment at `security-deep.yml:27-28`.

Scoping the env at job level (not workflow level) keeps `cargo-geiger` and `kani-verification` using the pre-shipped stable toolchain in the runner image — no wasted re-downloads.

## Test plan

- [ ] Security Medium workflow goes green on this branch
- [ ] Confirm cargo-geiger / Unsafe Code Tracking still uses the cached stable toolchain (not regressed)
- [ ] Next nightly Security Deep run picks up the fix and miri-full + fuzzing jobs pass install step

`refs rust-lang/rustup#1239`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/security workflow configurations to improve build process reliability during toolchain setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cachekit-io/cachekit-py/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->