### PR TITLE
test: fix MASTER_KEY env leak that broke 14 integration tests post #127

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -279,7 +279,7 @@
         "filename": "tests/critical/test_encryption_integration.py",
         "hashed_secret": "a002a64509e4963dc65ac47144b6c3fac8c683ae",
         "is_verified": false,
-        "line_number": 40
+        "line_number": 39
       }
     ],
     "tests/critical/test_encryption_wrapper.py": [
@@ -425,5 +425,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-28T00:50:38Z"
+  "generated_at": "2026-05-28T21:08:20Z"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -445,28 +445,29 @@ def reset_call_counters(*mock_objects):
 # Keep existing fixtures for backward compatibility
 @pytest.fixture(autouse=True)
 def setup_redis_env():
-    """Legacy fixture for backward compatibility."""
+    """Legacy fixture for backward compatibility.
 
-    # Use test database by default
+    Previously also set CACHEKIT_MASTER_KEY for every test. That broke after the
+    PR #127 auto-detect: any cached settings singleton that captured the env-set
+    master key turned encryption on globally, which the v0.6.0 cross-SDK rule
+    then rejected for non-default serializers (serializer='auto', custom
+    instances). Tests that need encryption now set CACHEKIT_MASTER_KEY locally
+    via monkeypatch.setenv.
+
+    reset_settings() brackets each test so the singleton never carries env
+    state across test boundaries.
+    """
+    from cachekit.config.singleton import reset_settings
+
     original_db = os.environ.get("REDIS_POOL_DB")
     os.environ.setdefault("REDIS_POOL_DB", "15")
-
-    # Set up master key for encryption tests (deterministic for reproducibility)
-    original_master_key = os.environ.get("CACHEKIT_MASTER_KEY")
-    if original_master_key is None:
-        # Use a fixed test master key (not secret, just for testing)
-        test_master_key = "a" * 64  # 32 bytes in hex = 64 hex chars
-        os.environ["CACHEKIT_MASTER_KEY"] = test_master_key
+    reset_settings()
 
     yield
 
-    # Restore original settings
     if original_db is not None:
         os.environ["REDIS_POOL_DB"] = original_db
-    if original_master_key is None and "CACHEKIT_MASTER_KEY" in os.environ:
-        del os.environ["CACHEKIT_MASTER_KEY"]
-    elif original_master_key is not None:
-        os.environ["CACHEKIT_MASTER_KEY"] = original_master_key
+    reset_settings()
 
 
 # =============================================================================

--- a/tests/critical/test_encryption_integration.py
+++ b/tests/critical/test_encryption_integration.py
@@ -7,7 +7,6 @@ Tests complete encryption flow from decorator through Redis storage.
 
 from __future__ import annotations
 
-import os
 import uuid
 
 import pytest
@@ -146,73 +145,33 @@ class TestEncryptionIntegration(RedisIsolationMixin):
         # (due to different derived encryption keys)
         assert ciphertext1 != ciphertext2, "Same plaintext with different tenant_ids must produce different ciphertext"
 
-    def test_master_key_validation_missing_key(self):
-        """CRITICAL: Missing CACHEKIT_MASTER_KEY must fail validation at decoration time.
-
-        Note: This test verifies validation logic exists and is correctly placed at decoration time.
-        The autouse fixture in conftest.py sets CACHEKIT_MASTER_KEY, so we validate via config module directly.
-        """
+    def test_master_key_validation_missing_key(self, monkeypatch):
+        """CRITICAL: Missing CACHEKIT_MASTER_KEY must fail validation at decoration time."""
         from cachekit.config import ConfigurationError, reset_settings, validate_encryption_config
 
-        # Save and remove master key temporarily
-        original_key = os.environ.get("CACHEKIT_MASTER_KEY")
-        try:
-            if "CACHEKIT_MASTER_KEY" in os.environ:
-                del os.environ["CACHEKIT_MASTER_KEY"]
+        monkeypatch.delenv("CACHEKIT_MASTER_KEY", raising=False)
+        reset_settings()
 
-            # Reset settings to pick up the env change
-            reset_settings()
+        with pytest.raises(ConfigurationError) as exc_info:
+            validate_encryption_config(encryption=True)
 
-            # Direct validation should fail when master key missing
-            with pytest.raises(ConfigurationError) as exc_info:
-                validate_encryption_config(encryption=True)
+        error_msg = str(exc_info.value).lower()
+        assert "master" in error_msg or "key" in error_msg, f"Expected key/master in error, got: {exc_info.value}"
 
-            # Should raise an error about missing master key
-            error_msg = str(exc_info.value).lower()
-            assert "master" in error_msg or "key" in error_msg, f"Expected key/master in error, got: {exc_info.value}"
-
-        finally:
-            # Restore original key
-            if original_key is not None:
-                os.environ["CACHEKIT_MASTER_KEY"] = original_key
-
-            # Reset settings again
-            reset_settings()
-
-    def test_master_key_validation_invalid_length(self):
-        """CRITICAL: Master key with invalid length must fail validation at decoration time.
-
-        Note: This test verifies validation logic exists and is correctly placed at decoration time.
-        The autouse fixture in conftest.py sets CACHEKIT_MASTER_KEY, so we validate via config module directly.
-        """
+    def test_master_key_validation_invalid_length(self, monkeypatch):
+        """CRITICAL: Master key with invalid length must fail validation at decoration time."""
         from cachekit.config import ConfigurationError, reset_settings, validate_encryption_config
 
-        # Save and replace with invalid key temporarily
-        original_key = os.environ.get("CACHEKIT_MASTER_KEY")
-        try:
-            # Set too-short master key (less than 32 bytes)
-            os.environ["CACHEKIT_MASTER_KEY"] = "too_short_key"
+        monkeypatch.setenv("CACHEKIT_MASTER_KEY", "too_short_key")
+        reset_settings()
 
-            # Reset settings to pick up the env change
-            reset_settings()
+        with pytest.raises(ConfigurationError) as exc_info:
+            validate_encryption_config(encryption=True)
 
-            # Direct validation should fail when master key invalid
-            with pytest.raises(ConfigurationError) as exc_info:
-                validate_encryption_config(encryption=True)
-
-            # Should raise an error about key format/length/encoding
-            error_msg = str(exc_info.value).lower()
-            assert any(kw in error_msg for kw in ["length", "32", "bytes", "hex", "encode"]), (
-                f"Expected validation error (length/32/bytes/hex/encode), got: {exc_info.value}"
-            )
-
-        finally:
-            # Restore original key
-            if original_key is not None:
-                os.environ["CACHEKIT_MASTER_KEY"] = original_key
-
-            # Reset settings again
-            reset_settings()
+        error_msg = str(exc_info.value).lower()
+        assert any(kw in error_msg for kw in ["length", "32", "bytes", "hex", "encode"]), (
+            f"Expected validation error (length/32/bytes/hex/encode), got: {exc_info.value}"
+        )
 
     def test_aes_gcm_authentication_prevents_tampering(self):
         """CRITICAL: AES-256-GCM authentication tags must prevent data tampering."""

--- a/tests/integration/test_serializer_integration.py
+++ b/tests/integration/test_serializer_integration.py
@@ -241,60 +241,15 @@ class TestSerializerGracefulDegradation:
         assert call_count == 2  # Function executed again (no cache)
 
 
-@pytest.mark.integration
-class TestSerializerWithEncryptionInProduction:
-    """Test serializer + encryption integration (production-like scenarios)."""
-
-    @pytest.fixture(autouse=True)
-    def setup_encryption(self):
-        """Set up encryption master key."""
-        original_master_key = os.environ.get("CACHEKIT_MASTER_KEY")
-        test_master_key = "a" * 64
-        os.environ["CACHEKIT_MASTER_KEY"] = test_master_key
-
-        yield
-
-        if original_master_key is not None:
-            os.environ["CACHEKIT_MASTER_KEY"] = original_master_key
-        else:
-            if "CACHEKIT_MASTER_KEY" in os.environ:
-                del os.environ["CACHEKIT_MASTER_KEY"]
-
-    def test_arrow_dataframe_caching_works_correctly(self, redis_isolated):
-        """ArrowSerializer caching with DataFrames works end-to-end."""
-        call_count = 0
-
-        @cache(ttl=300, serializer=ArrowSerializer())
-        def load_data(user_id: str) -> pd.DataFrame:
-            nonlocal call_count
-            call_count += 1
-            return pd.DataFrame({"user_id": [user_id], "balance": [call_count * 1000.0]})
-
-        # First call - cache miss
-        df1 = load_data("user-123")
-        assert call_count == 1
-        assert df1["balance"].iloc[0] == 1000.0
-
-        # Verify data in Redis exists
-        keys = redis_isolated.keys("*")
-        assert len(keys) > 0
-
-        # Second call - cache hit
-        df2 = load_data("user-123")
-        assert call_count == 1  # No additional function call (cache hit)
-        pd.testing.assert_frame_equal(df2, df1)
-
-    def test_dataframe_index_preserved_with_arrow_serializer(self, redis_isolated):
-        """DataFrame index is preserved with ArrowSerializer caching."""
-
-        @cache(ttl=300, serializer=ArrowSerializer())
-        def get_indexed_data() -> pd.DataFrame:
-            return pd.DataFrame({"value": [10, 20, 30]}, index=["a", "b", "c"])
-
-        df1 = get_indexed_data()
-        assert list(df1.index) == ["a", "b", "c"]
-
-        # Cache hit should preserve index
-        df2 = get_indexed_data()
-        pd.testing.assert_frame_equal(df2, df1)
-        assert list(df2.index) == ["a", "b", "c"]
+# TestSerializerWithEncryptionInProduction was removed: the tests combined
+# `@cache(serializer=ArrowSerializer())` with `CACHEKIT_MASTER_KEY` to assert that
+# Arrow encoding flows through the encryption path. That combination was never
+# end-to-end functional — cache_handler.py creates `EncryptionWrapper` without
+# passing the user's serializer, so the wrapper silently fell back to
+# StandardSerializer (MessagePack), not Arrow. The v0.6.0 cross-SDK rule
+# (cache_handler.py:351-362) made that silent substitution loud by rejecting
+# the configuration outright.
+#
+# Making this combination actually work requires threading the user's
+# serializer into EncryptionWrapper, marking serializers as cross-SDK
+# compatible, and updating strategy/saas-protocol-v1.0.md. Tracked separately.


### PR DESCRIPTION
## Summary

CI's Tests jobs have been red since PR #127 (May 28) — 14 integration tests fail with `ConfigurationError: Encryption requires 'default' serializer for cross-language interop` on all six Python versions, e.g. [run 26573103303](https://github.com/cachekit-io/cachekit-py/actions/runs/26573103303).

## Root cause (three bugs that compose)

1. `tests/conftest.py:setup_redis_env` pre-set `CACHEKIT_MASTER_KEY="a"*64` for every test. Inert before #127. After #127, `CacheSerializationHandler.__init__` reads `get_settings()` and auto-enables encryption when MASTER_KEY is present.
2. The v0.6.0 cross-SDK rule (`cache_handler.py:351-362`) rejects `serializer='auto'` / custom serializer instances with encryption on. Combined with #1, every test using AutoSerializer or ArrowSerializer started failing at decoration time.
3. `test_master_key_validation_invalid_length` wrote `"too_short_key"` straight to `os.environ` with a `try/finally` that only restored the env `if original_key is not None`. Once #1 is removed, `original_key` is None, the restore branch is skipped, and `"too_short_key"` leaks into every subsequent test's `bytes.fromhex()`.

## Fix

- Remove the implicit MASTER_KEY set from `setup_redis_env`. All 14 encryption-using test files already `monkeypatch.setenv("CACHEKIT_MASTER_KEY", ...)` explicitly.
- Add `reset_settings()` brackets to `setup_redis_env` so the `get_settings()` singleton can never carry env state across tests.
- Convert the two master-key validation tests in `test_encryption_integration.py` to `monkeypatch.setenv`/`delenv` so cleanup is automatic.
- Remove the 2 `TestSerializerWithEncryptionInProduction` tests. They asserted that `@cache(serializer=ArrowSerializer())` + MASTER_KEY flowed Arrow through encryption — it never did. `cache_handler.py:497-498` builds `EncryptionWrapper` without passing the user's serializer, so the wrapper silently fell back to `StandardSerializer`. The v0.6.0 rule made that silent substitution loud. **Real fix for Arrow+encryption needs `cache_handler.py:498` wired up, a `cross_sdk_compatible` marker on `SerializerProtocol`, and a protocol-spec update — tracked as a separate follow-up.**

## Test plan

- [x] 1448 unit tests pass locally with clean env
- [x] 493 critical+integration tests pass locally with clean env (was 14 failed → 0)
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by preventing cross-test persistence of cached settings.
  * Refactored encryption validation tests to use standard pytest patterns.
  * Removed an incomplete end-to-end serializer with encryption test case that was not fully validating the feature.

* **Chores**
  * Updated secret baseline configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cachekit-io/cachekit-py/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->