### PR TITLE
ci: restore Security Deep pipeline and gate publish on attestation

### DIFF
--- a/.github/workflows/attestation-check.yml
+++ b/.github/workflows/attestation-check.yml
@@ -27,14 +27,39 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Python
+        if: steps.release.outputs.skip != 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
       - name: Verify attestations
         if: steps.release.outputs.skip != 'true'
         run: |
-          echo "Verifying attestations for ${{ steps.release.outputs.tag }}"
-          gh attestation list --repo ${{ github.repository }} --limit 1 | grep -q "." || {
-            echo "::error::No attestations found for latest release"
+          # `gh attestation` has no `list` subcommand — the old query errored in
+          # ~8s every run (that was the real cause of the weekly red, not missing
+          # attestations). Verify the actual published artifact instead.
+          VER="${{ steps.release.outputs.tag }}"
+          VER="${VER#v}"
+          echo "Verifying attestations for cachekit ${VER}"
+          mkdir -p attest-check
+          if ! pip download "cachekit==${VER}" --no-deps --only-binary :all: -d attest-check; then
+            echo "::error::Could not download wheel for ${VER} from PyPI"
             exit 1
-          }
+          fi
+          shopt -s nullglob
+          files=(attest-check/*.whl)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No wheel downloaded for ${VER}"
+            exit 1
+          fi
+          for f in "${files[@]}"; do
+            echo "Verifying attestation for $f"
+            gh attestation verify "$f" --repo ${{ github.repository }} || {
+              echo "::error::Attestation verification failed for $f"
+              exit 1
+            }
+          done
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -229,7 +229,9 @@ jobs:
 
   publish:
     name: Publish to PyPI
-    needs: [release-please, build-wheels, build-sdist]
+    # Gate publish on attest: a paid security product must not ship wheels without
+    # verified build provenance. If attest fails, publish is skipped (re-runnable).
+    needs: [release-please, build-wheels, build-sdist, attest]
     if: ${{ !failure() && !cancelled() && (needs.release-please.outputs.release_created == 'true' || github.event.inputs.force_release == 'true') }}
     runs-on: ubuntu-latest
     environment: release

--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -18,8 +18,17 @@ jobs:
     name: Kani Formal Verification
     runs-on: cachekit
     timeout-minutes: 30
+    env:
+      # Pin rustup/cargo to /tmp (single fs) to avoid EXDEV on toolchain staging,
+      # and so the kani-verifier binary lands in a known, PATH-able location. The
+      # runner's default CARGO_HOME/bin is not on PATH, so cargo-kani exited 127.
+      RUSTUP_HOME: /tmp/rustup
+      CARGO_HOME: /tmp/cargo
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Put cargo bin on PATH
+      run: echo "/tmp/cargo/bin" >> "$GITHUB_PATH"
 
     - name: Ensure stable toolchain
       run: |
@@ -52,8 +61,11 @@ jobs:
 
     - name: Install nightly Rust
       run: |
-        rustup toolchain install nightly
-        rustup default nightly
+        # Pin nightly: cargo-fuzz 0.13.1 → rustix uses rustc_layout_scalar_valid_range_*
+        # attributes reserved after nightly-2026-04-27. Last known-good date.
+        # Same pin as fuzz-smoke.yml.
+        rustup toolchain install nightly-2026-04-27
+        rustup default nightly-2026-04-27
 
     - name: Install cargo-fuzz
       run: cargo install --locked cargo-fuzz
@@ -68,10 +80,13 @@ jobs:
         cd rust
         timeout 3600 cargo fuzz run byte_storage_decompress --no-default-features --features compression,checksum || true
 
-    - name: Fuzz encryption_roundtrip (1 hour)
+    # NOTE: encryption_roundtrip and 8 other encryption targets are stale against
+    # cachekit-core 0.1.1 (encrypt_aes_gcm → encrypt_with_keys). See #114. Using
+    # encryption_key_derivation, which compiles, until those targets are migrated.
+    - name: Fuzz encryption_key_derivation (1 hour)
       run: |
         cd rust
-        timeout 3600 cargo fuzz run encryption_roundtrip --no-default-features --features encryption || true
+        timeout 3600 cargo fuzz run encryption_key_derivation --no-default-features --features encryption || true
 
     - name: Check for crashes
       run: |
@@ -87,7 +102,7 @@ jobs:
     - name: Generate coverage report
       run: |
         cd rust
-        for target in byte_storage_compress byte_storage_decompress encryption_roundtrip; do
+        for target in byte_storage_compress byte_storage_decompress encryption_key_derivation; do
           echo "=== Coverage for $target ==="
           cargo fuzz coverage $target || true
         done
@@ -156,6 +171,12 @@ jobs:
     name: Sanitizers (ASan, TSan, MSan)
     runs-on: cachekit
     timeout-minutes: 40
+    env:
+      # Avoid EXDEV "cross-device link" errors when rustup stages the nightly
+      # toolchain / rust-src across overlay/hostPath boundaries on the ARC runner
+      # pod (rust-lang/rustup#1239). Same pattern as fuzzing / miri-full jobs.
+      RUSTUP_HOME: /tmp/rustup
+      CARGO_HOME: /tmp/cargo
     strategy:
       fail-fast: false
       matrix:
@@ -240,7 +261,7 @@ jobs:
         Status: ${{ needs.fuzzing.result }}
         - byte_storage_compress (1 hour)
         - byte_storage_decompress (1 hour)
-        - encryption_roundtrip (1 hour)
+        - encryption_key_derivation (1 hour)
 
         ### Undefined Behavior Detection (Miri)
         Status: ${{ needs.miri-full.result }}
@@ -280,6 +301,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [kani-verification, fuzzing, atheris-fuzzing, miri-full, sanitizers]
     if: always()
+    permissions:
+      contents: read
+      issues: write
     steps:
     - name: Check all deep security checks passed
       run: |
@@ -297,3 +321,29 @@ jobs:
           exit 1
         fi
         echo "✅ All deep security checks passed"
+
+    # Surface nightly failures: a schedule-only job that fails silently is worse
+    # than no job. De-duplicate by title so we don't open a new issue every night.
+    - name: File / update tracking issue on failure
+      if: failure()
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TITLE: "Security Deep nightly is failing"
+      run: |
+        body=$(printf '%s\n' \
+          "Security Deep failed on run ${{ github.run_id }}." \
+          "" \
+          "- Kani: ${{ needs.kani-verification.result }}" \
+          "- Fuzzing: ${{ needs.fuzzing.result }}" \
+          "- Atheris: ${{ needs.atheris-fuzzing.result }}" \
+          "- Miri: ${{ needs.miri-full.result }}" \
+          "- Sanitizers: ${{ needs.sanitizers.result }}" \
+          "" \
+          "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}")
+        existing=$(gh issue list --repo "${{ github.repository }}" --state open \
+          --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+        if [ -n "$existing" ]; then
+          gh issue comment "$existing" --repo "${{ github.repository }}" --body "$body"
+        else
+          gh issue create --repo "${{ github.repository }}" --title "$TITLE" --label bug --body "$body"
+        fi


### PR DESCRIPTION
## Why

`Security Deep` (nightly ASan/TSan/MSan, Kani, fuzzing) has been **red every night for weeks** — and because it's schedule-only, not a required check, and had no alerting, nobody was told. Four independent root causes, plus a release pipeline that can publish wheels without provenance. For a product whose differentiator is zero-knowledge encryption, that validation gap matters more right before a paid launch.

## What

**`security-deep.yml`**
- **sanitizers** — added `RUSTUP_HOME`/`CARGO_HOME=/tmp` (the matrix job was missing the pin that `fuzzing` and `miri-full` already have). Fixes `Invalid cross-device link (os error 18)` when rustup stages nightly/rust-src across the ARC runner's overlay/hostPath boundary.
- **fuzzing** — pinned `nightly-2026-04-27` (cargo-fuzz 0.13.1's `rustix` won't compile on newer nightly: `rustc_layout_scalar_valid_range_*` reserved). Swapped the stale `encryption_roundtrip` target for `encryption_key_derivation`, which compiles against cachekit-core 0.1.1.
- **kani** — pinned `CARGO_HOME` and put its `bin` on `PATH`; `cargo-kani` was installed but not on `PATH`, so the job exited `127`.
- **security-deep-success** — opens/updates a single tracking issue on failure. A schedule-only job that fails silently is worse than no job.

**`release-please.yml`**
- `publish` now `needs: [..., attest]`. If attestation fails, publish is skipped (re-runnable). No unattested wheels.

**`attestation-check.yml`**
- The weekly check called `gh attestation list` — **not a real `gh` subcommand** (only `download`/`trusted-root`/`verify` exist). That's why it errored in ~8s every week (the real cause behind #126, not missing attestations). Now downloads the published wheel and runs `gh attestation verify`.

## Not in this PR

The other **9 encryption fuzz targets** (`encrypt_aes_gcm` → `encrypt_with_keys`, #114) need the cachekit-core 0.1.1 API migration **and local build verification** — that's a separate, build-verified PR, not something to ship blind here.

## Verify

`Security Deep` is schedule-only, so it won't run on this PR. After merge (or now, against this branch), trigger it manually to confirm green:

```
gh workflow run security-deep.yml --ref ci/restore-security-deep-pipeline
```

Refs #114, #126.
