### PR TITLE
feat: auto-detect memcached and file backends from environment

### DIFF
--- a/src/cachekit/backends/provider.py
+++ b/src/cachekit/backends/provider.py
@@ -104,36 +104,85 @@ class DefaultCacheClientProvider(CacheClientProvider):
 class DefaultBackendProvider(BackendProviderInterface):
     """Default backend provider with env-based auto-detection.
 
-    Priority order (first matching env var wins):
-        1. CACHEKIT_API_KEY  → CachekitIOBackend (SaaS)
-        2. CACHEKIT_REDIS_URL or REDIS_URL → RedisBackend
+    Selection is by a single, unambiguous environment signal. Priority order:
+        1. CACHEKIT_API_KEY            → CachekitIOBackend (SaaS)
+        2. CACHEKIT_REDIS_URL          → RedisBackend
+        3. CACHEKIT_MEMCACHED_SERVERS  → MemcachedBackend
+        4. CACHEKIT_FILE_CACHE_DIR     → FileBackend
+        5. REDIS_URL, or nothing set   → RedisBackend (12-factor / localhost default)
 
-    For single-tenant deployments (default), sets tenant_context to "default".
-    For multi-tenant deployments, tenant_context must be set externally.
+    Setting more than one of the four prefixed selectors (1-4) raises
+    ``ConfigurationError`` — auto-detection must be unambiguous; pass
+    ``backend=`` explicitly to override. The non-prefixed ``REDIS_URL`` is only a
+    fallback and never counts as a conflict (12-factor convention).
+
+    CachekitIO/Memcached/File backends are stateless singletons (cached). Redis
+    backends are per-request tenant-scoped wrappers (not cached —
+    RedisBackendProvider.get_backend() reads the tenant_context ContextVar). For
+    single-tenant deployments (default), tenant_context is set to "default".
     """
+
+    # Prefixed selectors in priority order. REDIS_URL is the implicit fallback
+    # and intentionally excluded so it never triggers a conflict.
+    _SELECTORS = (
+        ("CACHEKIT_API_KEY", "cachekitio"),
+        ("CACHEKIT_REDIS_URL", "redis"),
+        ("CACHEKIT_MEMCACHED_SERVERS", "memcached"),
+        ("CACHEKIT_FILE_CACHE_DIR", "file"),
+    )
 
     def __init__(self):
         self._cachekitio_backend = None
         self._redis_provider = None
+        self._memcached_backend = None
+        self._file_backend = None
 
-    def get_backend(self):
-        """Get backend instance, auto-detected from environment on first call.
+    def _detect(self):
+        """Return the chosen backend key, or None to use the Redis fallback.
 
-        CachekitIO backends are stateless singletons (cached).
-        Redis backends are per-request tenant-scoped wrappers (not cached —
-        RedisBackendProvider.get_backend() reads tenant_context ContextVar).
+        Raises ConfigurationError if more than one prefixed selector is set.
         """
         import os
 
-        # Priority 1: CachekitIO SaaS backend (stateless, safe to cache)
-        if os.environ.get("CACHEKIT_API_KEY"):
+        matched = [(env_var, key) for env_var, key in self._SELECTORS if os.environ.get(env_var)]
+        if len(matched) > 1:
+            from cachekit.config.validation import ConfigurationError
+
+            names = ", ".join(env_var for env_var, _ in matched)
+            raise ConfigurationError(
+                f"Ambiguous backend auto-detection: multiple selectors set ({names}). "
+                "Set exactly one of CACHEKIT_API_KEY / CACHEKIT_REDIS_URL / "
+                "CACHEKIT_MEMCACHED_SERVERS / CACHEKIT_FILE_CACHE_DIR, or pass backend= explicitly."
+            )
+        return matched[0][1] if matched else None
+
+    def get_backend(self):
+        """Get backend instance, auto-detected from environment on first call."""
+        choice = self._detect()
+
+        if choice == "cachekitio":
             if self._cachekitio_backend is None:
                 from cachekit.backends.cachekitio import CachekitIOBackend
 
                 self._cachekitio_backend = CachekitIOBackend()
             return self._cachekitio_backend
 
-        # Priority 2: Redis backend (tenant-scoped, call provider each time)
+        if choice == "memcached":
+            if self._memcached_backend is None:
+                from cachekit.backends.memcached import MemcachedBackend, MemcachedBackendConfig
+
+                self._memcached_backend = MemcachedBackend(MemcachedBackendConfig.from_env())
+            return self._memcached_backend
+
+        if choice == "file":
+            if self._file_backend is None:
+                from cachekit.backends.file import FileBackend, FileBackendConfig
+
+                self._file_backend = FileBackend(FileBackendConfig.from_env())
+            return self._file_backend
+
+        # choice == "redis" (explicit CACHEKIT_REDIS_URL) or None (REDIS_URL / localhost fallback).
+        # Tenant-scoped: call the provider each time so it re-reads tenant_context.
         if self._redis_provider is None:
             from cachekit.backends.redis.config import RedisBackendConfig
             from cachekit.backends.redis.provider import RedisBackendProvider, tenant_context

--- a/tests/unit/backends/test_provider.py
+++ b/tests/unit/backends/test_provider.py
@@ -11,6 +11,7 @@ Tests for backends/provider.py covering:
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -368,3 +369,90 @@ class TestDefaultBackendProvider:
                         provider.get_backend()
 
                         mock_context.set.assert_not_called()
+
+    def test_init_includes_memcached_and_file_caches(self) -> None:
+        """New cached fields start as None."""
+        provider = DefaultBackendProvider()
+        assert provider._memcached_backend is None
+        assert provider._file_backend is None
+
+    def test_get_backend_returns_memcached_when_servers_set(self) -> None:
+        """CACHEKIT_MEMCACHED_SERVERS → MemcachedBackend."""
+        provider = DefaultBackendProvider()
+
+        with mock.patch.dict("os.environ", {"CACHEKIT_MEMCACHED_SERVERS": '["127.0.0.1:11211"]'}, clear=True):
+            with mock.patch("cachekit.backends.memcached.MemcachedBackend") as mock_mc:
+                with mock.patch("cachekit.backends.memcached.MemcachedBackendConfig"):
+                    mock_instance = mock.MagicMock()
+                    mock_mc.return_value = mock_instance
+
+                    backend = provider.get_backend()
+
+                    assert backend is mock_instance
+                    mock_mc.assert_called_once()
+
+    def test_get_backend_returns_file_when_cache_dir_set(self, tmp_path: Path) -> None:
+        """CACHEKIT_FILE_CACHE_DIR → FileBackend."""
+        provider = DefaultBackendProvider()
+
+        with mock.patch.dict("os.environ", {"CACHEKIT_FILE_CACHE_DIR": str(tmp_path)}, clear=True):
+            with mock.patch("cachekit.backends.file.FileBackend") as mock_file:
+                with mock.patch("cachekit.backends.file.FileBackendConfig"):
+                    mock_instance = mock.MagicMock()
+                    mock_file.return_value = mock_instance
+
+                    backend = provider.get_backend()
+
+                    assert backend is mock_instance
+                    mock_file.assert_called_once()
+
+    def test_get_backend_explicit_redis_url(self) -> None:
+        """CACHEKIT_REDIS_URL is an explicit selector → RedisBackend."""
+        provider = DefaultBackendProvider()
+
+        with mock.patch.dict("os.environ", {"CACHEKIT_REDIS_URL": "redis://localhost:6379"}, clear=True):
+            with mock.patch("cachekit.backends.redis.config.RedisBackendConfig") as mock_config_class:
+                with mock.patch("cachekit.backends.redis.provider.RedisBackendProvider") as mock_provider_class:
+                    with mock.patch("cachekit.backends.redis.provider.tenant_context") as mock_context:
+                        mock_config_class.from_env.return_value = mock.MagicMock(redis_url="redis://localhost:6379")
+                        mock_provider_instance = mock.MagicMock()
+                        mock_backend_instance = mock.MagicMock()
+                        mock_provider_class.return_value = mock_provider_instance
+                        mock_provider_instance.get_backend.return_value = mock_backend_instance
+                        mock_context.get.return_value = None
+
+                        backend = provider.get_backend()
+
+                        assert backend is mock_backend_instance
+
+    def test_get_backend_raises_on_ambiguous_selectors(self) -> None:
+        """More than one prefixed selector → ConfigurationError (unambiguous auto-detect)."""
+        from cachekit.config.validation import ConfigurationError
+
+        provider = DefaultBackendProvider()
+
+        with mock.patch.dict(
+            "os.environ",
+            {"CACHEKIT_API_KEY": _FAKE_API_KEY, "CACHEKIT_REDIS_URL": "redis://localhost:6379"},
+            clear=True,
+        ):
+            with pytest.raises(ConfigurationError, match="Ambiguous backend"):
+                provider.get_backend()
+
+    def test_redis_url_fallback_is_not_a_conflict(self) -> None:
+        """Non-prefixed REDIS_URL alongside a prefixed selector is a fallback, not a conflict."""
+        provider = DefaultBackendProvider()
+
+        with mock.patch.dict(
+            "os.environ",
+            {"CACHEKIT_API_KEY": _FAKE_API_KEY, "REDIS_URL": "redis://localhost:6379"},
+            clear=True,
+        ):
+            with mock.patch("cachekit.backends.cachekitio.CachekitIOBackend") as mock_ckio:
+                mock_instance = mock.MagicMock()
+                mock_ckio.return_value = mock_instance
+
+                backend = provider.get_backend()
+
+                # API_KEY wins; REDIS_URL is ignored and does not raise.
+                assert backend is mock_instance


### PR DESCRIPTION
## Why

`DefaultBackendProvider` only auto-detected `CACHEKIT_API_KEY` and Redis, even though the README/CLAUDE.md advertise a five-variable table and the `.claude/rules/backend-conventions.md` requires conflict handling. The docs over-promised; this makes them true.

## What

Completes env-based auto-detection in `DefaultBackendProvider.get_backend()`:

| Env var | Backend |
|---|---|
| `CACHEKIT_API_KEY` | CachekitIO (SaaS) |
| `CACHEKIT_REDIS_URL` | Redis (explicit) |
| **`CACHEKIT_MEMCACHED_SERVERS`** | **Memcached** (new) |
| **`CACHEKIT_FILE_CACHE_DIR`** | **File** (new) |
| `REDIS_URL` / nothing set | Redis (12-factor / localhost default) |

- **Unambiguous selection**: setting more than one *prefixed* selector raises `ConfigurationError` (per the backend-conventions rule). The non-prefixed `REDIS_URL` is only a fallback and never counts as a conflict.
- **Backward compatible**: Redis stays the default when nothing is set; existing single-selector deployments behave exactly as before.
- Memcached/File backends are cached singletons; Redis stays tenant-scoped.

## Tests

6 new unit tests (memcached, file, explicit redis, ambiguous-selector raises, REDIS_URL-not-a-conflict, new cache fields). `tests/unit/backends/` + `tests/unit/config/`: **510 passed, 2 skipped**. ruff + basedpyright clean.

## Supersedes

Collapses the duplicate implementations into one: closes #87, supersedes #88 (broader scope-creep impl, 26 commits behind, conflicting) and #120 (cleaner but conflicting). This branch is fresh off current `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cache backend auto-detection now supports Memcached and File-based storage options in addition to existing providers.

* **Improvements**
  * Enhanced conflict detection when multiple cache backends are configured, providing clearer error messaging for ambiguous setups.

* **Tests**
  * Added comprehensive test coverage for backend selection and configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cachekit-io/cachekit-py/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->