### PR TITLE
ci: pin Atheris fuzzing job to Python 3.11

### DIFF
--- a/.github/workflows/security-deep.yml
+++ b/.github/workflows/security-deep.yml
@@ -114,16 +114,21 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+    # Pin to 3.11: atheris 2.3.0's newest prebuilt wheel is cp311. On a newer
+    # interpreter uv builds atheris from sdist, which needs clang + libFuzzer
+    # (find_libfuzzer.sh) — absent on the self-hosted runner, so install fails
+    # before any fuzzing runs. Both uv sync and uv run must pin, or uv run
+    # re-resolves to a different interpreter and re-triggers the source build.
     - name: Install dependencies
       run: |
-        uv sync --group dev --group fuzz
+        uv sync --group dev --group fuzz --python 3.11
 
     - name: Run Atheris fuzz targets (10 min each)
       run: |
         for fuzz_target in tests/fuzzing/fuzz_*.py; do
           if [ -f "$fuzz_target" ]; then
             echo "Fuzzing $fuzz_target..."
-            timeout 10m uv run python "$fuzz_target" -max_total_time=600 || true
+            timeout 10m uv run --python 3.11 python "$fuzz_target" -max_total_time=600 || true
           fi
         done
 


### PR DESCRIPTION
## Problem

The `Security Deep` workflow has been failing on the **Atheris Python-Rust Fuzzing** job ([run 26693957972](https://github.com/cachekit-io/cachekit-py/actions/runs/26693957972)). It is **not a fuzz finding** — no crashes were found, the fuzzer never started. The job dies at dependency install.

## Root cause

The `atheris-fuzzing` job had **no Python pin**, so `uv` floated to its newest managed interpreter — `cpython-3.14.5`. But `atheris==2.3.0` ships prebuilt wheels only through **cp311** (cp36–cp311; none for 3.12/3.13/3.14). On 3.14, `uv` fell back to building atheris from sdist, whose build step (`find_libfuzzer.sh`) requires **clang + libFuzzer**:

```
RuntimeError: Failed to find libFuzzer; set $CLANG_BIN ... or $LIBFUZZER_LIB
find_libfuzzer.sh returned non-zero exit status 1
```

The self-hosted `cachekit` runner has neither, so `uv sync` exited 1 before any fuzzing ran. It started failing when uv's bundled Python catalog advanced past atheris's wheel coverage.

## Fix

Pin **both** `uv sync` and `uv run` to **Python 3.11** — the newest version with an atheris wheel (already in the CI matrix). The wheel installs directly: no source build, no clang dependency on the runner. Both invocations are pinned because `uv run` re-resolves the interpreter independently.

Pinning to 3.12 would *not* work — atheris 2.3.0 has no cp312 wheel either.

## Testing

- `actionlint` passes (pre-commit).
- Verify on merge: the Atheris job installs from wheel and runs the fuzz targets instead of failing at install.

Non-blocking job (nightly Security Deep, doesn't gate releases), but it was hiding real future fuzz findings while red.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal security testing processes to ensure consistent execution environment during automated fuzzing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->