### PR TITLE
docs: lead with the pluggable-backend abstraction (conservative reframe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,17 @@ Or with [uv][uv-url] (recommended):
 uv add cachekit
 ```
 
-### Setup (Redis — recommended default)
+### Setup (choose a backend)
+
+cachekit exposes one decorator API over a pluggable backend abstraction. Pick the
+backend that fits your infrastructure — they're peers behind the same `@cache` API:
+
+| Backend | Best for | Select with |
+|---------|----------|-------------|
+| Redis | Self-hosted, full control | `REDIS_URL` / `CACHEKIT_REDIS_URL` |
+| CachekitIO | Managed, zero-ops (alpha) | `CACHEKIT_API_KEY` |
+| Memcached | High-throughput, existing infra | `CACHEKIT_MEMCACHED_SERVERS` |
+| File / L1-only | Local dev, tests, no external deps | `CACHEKIT_FILE_CACHE_DIR` / `backend=None` |
 
 ```bash
 # Run Redis locally or use your existing infrastructure
@@ -75,7 +85,7 @@ export REDIS_URL="redis://localhost:6379"
 ```python
 from cachekit import cache
 
-@cache  # Uses Redis backend by default
+@cache  # Auto-detects backend (defaults to Redis at localhost)
 def expensive_api_call(user_id: int):
     return fetch_user_data(user_id)
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Choose your storage backend:
 | Guide | Description |
 |:------|:------------|
 | [Backend Overview](backends/README.md) | Comparison and selection guide |
-| [Redis](backends/redis.md) | Production default, connection pooling |
+| [Redis](backends/redis.md) | Self-hosted, production-grade, connection pooling |
 | [File](backends/file.md) | Local filesystem, zero dependencies |
 | [Memcached](backends/memcached.md) | High-throughput, consistent hashing |
 | [CachekitIO](backends/cachekitio.md) | Managed SaaS, zero infrastructure |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ cachekit supports four backends. Pick the one that fits your infrastructure:
 | File | Local dev, testing | None |
 | Memcached | High-throughput, existing infra | `CACHEKIT_MEMCACHED_SERVERS` |
 
-**Redis is the recommended default.** CachekitIO is a managed alternative (currently in closed alpha). File backend is intended for local development and testing only. Memcached is an optional backend (`pip install cachekit[memcached]`).
+By default `@cache` auto-detects your backend from env vars, falling back to Redis at localhost (12-factor convention). CachekitIO is a managed alternative (currently in closed alpha). File backend is intended for local development and testing only. Memcached is an optional backend (`pip install cachekit[memcached]`).
 
 ### Redis Backend
 
@@ -30,7 +30,7 @@ For self-hosted Redis infrastructure:
 ```python
 from cachekit import cache
 
-@cache  # Uses Redis backend by default
+@cache  # Auto-detects backend (defaults to Redis at localhost)
 def fetch_data():
     return expensive_computation()
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@
 
 ## Table of Contents
 
-- [Quick Start with Redis](#quick-start-with-redis)
+- [Quick Start](#quick-start)
 - [Progressive Disclosure](#progressive-disclosure-choose-your-level)
 - [Installation](#installation)
 - [Choose Your Backend](#choose-your-backend)
@@ -20,9 +20,15 @@
 
 ---
 
-## Quick Start with Redis
+## Quick Start
 
-cachekit uses Redis as its backend:
+CacheKit provides a unified caching API with pluggable backends. You write `@cache`
+once; the backend (Redis, CachekitIO, Memcached, or File / L1-only) is selected from
+your environment. See [Choose Your Backend](#choose-your-backend) for the full menu.
+
+By default `@cache` auto-detects the backend from env vars, falling back to Redis at
+localhost (12-factor convention), so the fastest path to a working cache is to point
+it at a local Redis:
 
 ```bash
 # 1. Run Redis
@@ -35,7 +41,7 @@ export REDIS_URL="redis://localhost:6379"
 ```python
 from cachekit import cache
 
-@cache  # Uses Redis by default
+@cache  # Auto-detects backend (defaults to Redis at localhost)
 def expensive_function():
     return do_work()
 ```
@@ -222,7 +228,7 @@ docker run -p 6379:6379 redis
 ### Environment Setup
 
 ```bash
-# Redis (recommended default)
+# Redis (auto-detected default — falls back to localhost)
 export REDIS_URL="redis://localhost:6379"
 
 # Optional: explicit Redis configuration

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ CacheKit provides a unified caching API with pluggable backends. You write `@cac
 once; the backend (Redis, CachekitIO, Memcached, or File / L1-only) is selected from
 your environment. See [Choose Your Backend](#choose-your-backend) for the full menu.
 
-By default `@cache` auto-detects the backend from env vars, falling back to Redis at
+By default, `@cache` auto-detects the backend from env vars, falling back to Redis at
 localhost (12-factor convention), so the fastest path to a working cache is to point
 it at a local Redis:
 


### PR DESCRIPTION
## Summary

Reframes the docs to lead with CacheKit's pluggable-backend abstraction and present the backends as peers behind the single `@cache` API, instead of opening with Redis as the headline choice.

Changes:
- **README.md** — `Setup (Redis — recommended default)` → `Setup (choose a backend)`, with a backend-selection table placed *before* the Redis quick-start. The `@cache` comment softened to `# Auto-detects backend (defaults to Redis at localhost)`.
- **docs/configuration.md** — `Redis is the recommended default.` → an accurate auto-detect statement; existing peer table and per-backend sections kept intact.
- **docs/getting-started.md** — intro now leads with "CacheKit provides a unified caching API with pluggable backends" and points to *Choose Your Backend*; the "Redis by default" comments aligned to the auto-detect wording. (TOC anchor updated to match the renamed `## Quick Start` heading; no other doc links to the old anchor.)
- **docs/README.md** — Redis row `Production default` → `Self-hosted, production-grade`.

## Why

The docs over-indexed on Redis, obscuring that CachekitIO, Memcached, and File / L1-only are first-class peers selectable purely via environment variables. Leading with the abstraction makes backend choice legible up front.

This is the **conservative positioning (Option A)**: Redis is the *verified code-level default* — `src/cachekit/backends/provider.py` auto-detects the backend from env vars and falls back to `RedisBackend` at localhost when nothing is configured. So "defaults to Redis at localhost" is **true**, not a bug. Rather than flatten everything to "all equal" (which would mislead zero-config users about what actually runs), default statements were *reworded for accuracy* and *kept*. The maintainer can dial the tone further up or down in review.

## Verification

- `uv sync --group dev`
- `uv run pytest tests/docs/ -q` → **70 passed**

Docs-only change; no code or API touched. Lockfiles intentionally excluded (only the four doc files are in the diff).

Closes #21


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded setup and configuration docs with a comprehensive backends table covering Redis, CachekitIO, Memcached and File/L1-only, and how to select each via environment settings.
  * Clarified that backend is auto-detected (falls back to Redis at localhost) and updated examples and quick-start flow to reflect this.
  * Revised backend descriptions to better match intended use and readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->