### PR TITLE
test: fix 9 broken fuzz targets and track cachekit-core 0.2.0

### DIFF
--- a/rust/fuzz/Cargo.toml
+++ b/rust/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ rmp-serde = "1"
 # not the thin PyO3 wrapper's flat re-exports.
 [dependencies.cachekit_storage]
 package = "cachekit-core"
-version = "=0.1.1"
+version = "=0.2.0"
 features = ["compression", "checksum", "messagepack", "encryption"]
 
 # Prevent this from interfering with normal build

--- a/rust/fuzz/fuzz_targets/byte_storage_checksum_collision.rs
+++ b/rust/fuzz/fuzz_targets/byte_storage_checksum_collision.rs
@@ -55,8 +55,9 @@ fuzz_target!(|test_case: ChecksumTestCase| {
             // If it succeeded, data must be unchanged (flip reverted or no-op)
             // This is only acceptable if flip_mask was 0 or flipped back to original
         }
-        Err(err_msg) => {
+        Err(err) => {
             // Expected: Checksum validation should fail
+            let err_msg = err.to_string();
             assert!(
                 err_msg.contains("Checksum validation failed") || err_msg.contains("decompression failed"),
                 "Error should indicate checksum or decompression failure: {}",
@@ -68,7 +69,7 @@ fuzz_target!(|test_case: ChecksumTestCase| {
     // Test with completely wrong checksum
     let wrong_checksum_envelope = StorageEnvelope {
         compressed_data: envelope.compressed_data.clone(),
-        checksum: [0xFF; 32], // Wrong checksum
+        checksum: [0xFF; 8], // Wrong checksum
         original_size: envelope.original_size,
         format: envelope.format.clone(),
     };
@@ -76,9 +77,10 @@ fuzz_target!(|test_case: ChecksumTestCase| {
     // Should be rejected unless original checksum happened to be all 0xFF
     match wrong_checksum_envelope.extract() {
         Ok(_) => {
-            // Only acceptable if original checksum was [0xFF; 32]
+            // Only acceptable if original checksum was [0xFF; 8]
         }
-        Err(err_msg) => {
+        Err(err) => {
+            let err_msg = err.to_string();
             assert!(
                 err_msg.contains("Checksum") || err_msg.contains("failed"),
                 "Wrong checksum should be detected: {}",

--- a/rust/fuzz/fuzz_targets/byte_storage_empty_data.rs
+++ b/rust/fuzz/fuzz_targets/byte_storage_empty_data.rs
@@ -11,7 +11,7 @@ struct EmptyDataTestCase {
     /// Compressed data length (can be 0)
     compressed_len: u8, // 0-255
     /// Checksum
-    checksum: [u8; 32],
+    checksum: [u8; 8],
 }
 
 fuzz_target!(|test_case: EmptyDataTestCase| {

--- a/rust/fuzz/fuzz_targets/byte_storage_integer_overflow.rs
+++ b/rust/fuzz/fuzz_targets/byte_storage_integer_overflow.rs
@@ -11,7 +11,7 @@ struct OverflowTestCase {
     /// Compressed data size (small to create suspicious ratios)
     compressed_data_len: u8, // 0-255 bytes
     /// Checksum bytes
-    checksum: [u8; 32],
+    checksum: [u8; 8],
     /// Format string
     format_len: u8, // 0-255 for format string length
 }
@@ -40,9 +40,10 @@ fuzz_target!(|test_case: OverflowTestCase| {
             // Decompression succeeded - envelope passed all validation checks
             // This should only happen for valid sizes within limits
         }
-        Err(err_msg) => {
+        Err(err) => {
             // Expected for oversized allocations (u32::MAX, beyond 512MB, etc.)
             // Verify error message is descriptive
+            let err_msg = err.to_string();
             assert!(
                 err_msg.contains("Security violation") || err_msg.contains("failed"),
                 "Error message should be descriptive: {}",

--- a/rust/fuzz/fuzz_targets/encryption_aad_injection.rs
+++ b/rust/fuzz/fuzz_targets/encryption_aad_injection.rs
@@ -19,7 +19,9 @@ fuzz_target!(|data: &[u8]| {
 
     let (plaintext, aad) = rest.split_at(rest.len() / 2);
 
-    let encryptor = ZeroKnowledgeEncryptor::new();
+    let Ok(encryptor) = ZeroKnowledgeEncryptor::new() else {
+        return;
+    };
 
     // Encrypt with potentially malicious AAD
     // AAD can contain: nulls, control chars, Unicode, empty, long strings

--- a/rust/fuzz/fuzz_targets/encryption_large_payload.rs
+++ b/rust/fuzz/fuzz_targets/encryption_large_payload.rs
@@ -20,7 +20,9 @@ fuzz_target!(|data: &[u8]| {
     let (key, plaintext) = data.split_at(32);
     let aad = b"large_payload_test";
 
-    let encryptor = ZeroKnowledgeEncryptor::new();
+    let Ok(encryptor) = ZeroKnowledgeEncryptor::new() else {
+        return;
+    };
 
     // Test encryption → decryption roundtrip
     let start = std::time::Instant::now();

--- a/rust/fuzz/fuzz_targets/encryption_nonce_reuse.rs
+++ b/rust/fuzz/fuzz_targets/encryption_nonce_reuse.rs
@@ -21,7 +21,9 @@ fuzz_target!(|data: &[u8]| {
     let (key, plaintext) = data.split_at(32);
     let aad = b"fuzz_test_aad";
 
-    let encryptor = ZeroKnowledgeEncryptor::new();
+    let Ok(encryptor) = ZeroKnowledgeEncryptor::new() else {
+        return;
+    };
 
     // Encrypt same plaintext multiple times
     let mut ciphertexts = HashSet::new();

--- a/rust/fuzz/fuzz_targets/encryption_roundtrip.rs
+++ b/rust/fuzz/fuzz_targets/encryption_roundtrip.rs
@@ -10,7 +10,9 @@ fuzz_target!(|data: &[u8]| {
     }
 
     // Create encryptor
-    let encryptor = ZeroKnowledgeEncryptor::new();
+    let Ok(encryptor) = ZeroKnowledgeEncryptor::new() else {
+        return;
+    };
 
     // Generate deterministic key and AAD from input
     // (In real usage, keys come from key derivation)

--- a/rust/fuzz/fuzz_targets/encryption_truncated_ciphertext.rs
+++ b/rust/fuzz/fuzz_targets/encryption_truncated_ciphertext.rs
@@ -15,7 +15,9 @@ fuzz_target!(|data: &[u8]| {
     let (key, plaintext) = data.split_at(32);
     let aad = b"test_aad";
 
-    let encryptor = ZeroKnowledgeEncryptor::new();
+    let Ok(encryptor) = ZeroKnowledgeEncryptor::new() else {
+        return;
+    };
 
     // Create valid ciphertext
     let ciphertext = match encryptor.encrypt_aes_gcm(plaintext, key, aad) {

--- a/rust/fuzz/fuzz_targets/integration_layered_security.rs
+++ b/rust/fuzz/fuzz_targets/integration_layered_security.rs
@@ -21,7 +21,9 @@ fuzz_target!(|data: &[u8]| {
     }
 
     let aad = b"layered_test";
-    let encryptor = ZeroKnowledgeEncryptor::new();
+    let Ok(encryptor) = ZeroKnowledgeEncryptor::new() else {
+        return;
+    };
 
     // Step 1: Create ByteStorage envelope (compression + checksum)
     let envelope = match StorageEnvelope::new(plaintext.to_vec(), "msgpack".to_string()) {


### PR DESCRIPTION
## Summary

Repairs all 14 fuzz targets in `rust/fuzz`, which had stopped compiling. Nine target files plus the crate manifest were touched.

The fuzz crate is workspace-excluded (`[workspace]` with no members), so it was skipped when the main crate moved to `cachekit-core 0.2.0` in #140. Combined with several pre-existing compile errors in the target bodies, the result was that `cargo check --bins` failed outright and the nightly fuzzing job had no working targets.

## What changed

- **Stale pin** -- `Cargo.toml`: `cachekit-core = "=0.1.1"` -> `"=0.2.0"`, so the fuzz crate tracks the main crate.
- **Wrong checksum width** -- `StorageEnvelope.checksum` is `[u8; 8]` (xxHash3-64), not `[u8; 32]`. The `Arbitrary` structs in `byte_storage_empty_data` and `byte_storage_integer_overflow`, and the literal in `byte_storage_checksum_collision`, all used `32` -- a hard type mismatch.
- **Result-returning constructor** -- `ZeroKnowledgeEncryptor::new()` returns `Result`. The six encryption/integration targets bound it as a plain value. Switched to `let Ok(encryptor) = ... else { return; }`, which is the right fuzz-harness behavior: skip the input on setup failure rather than panic.
- **Error type misuse** -- `StorageEnvelope::extract()` returns `Err(ByteStorageError)`, an enum with no `.contains()`. Bound the error and called `.to_string()` before the existing substring assertions (`byte_storage_integer_overflow`, `byte_storage_checksum_collision`).

## Why

This is test-only tooling with zero runtime/user impact, hence `test:`. Notably, the original issue's premise -- that `encrypt_aes_gcm` / `decrypt_aes_gcm` were renamed in 0.2.0 -- is incorrect. The `byte_storage` and `encryption` public surfaces are byte-identical between 0.1.1 and 0.2.0 on the native target (0.2.0 only adds wasm32-gated variants). So this is a pin-and-compile fix, not an API migration.

## Verification

`cargo check --bins` in `rust/fuzz` -- all 14 targets compile, 0 errors, 0 warnings:

```
   Compiling cachekit-core v0.2.0
    Checking cachekit-storage-fuzz v0.0.0 (.../rust/fuzz)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 15.06s
```

(`make fuzz-quick` not run -- it is long-running; `cargo check` is the compile gate for this change.)

Closes #114
