### PR TITLE
docs: document cache_info() and correct inaccurate Prometheus docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,12 +302,36 @@ See [SECURITY.md][security-url] for vulnerability reporting and detailed documen
 
 </details>
 
-### Built-in Monitoring
+### Monitoring & Observability
 
-- **Prometheus metrics** - Production-ready observability
+- **Per-function statistics** - `cache_info()` on every decorated function, modelled on `functools.lru_cache`
+- **Prometheus metrics** - Recorded by default (your app owns exposition)
 - **Structured logging** - Context-aware with correlation IDs
 - **Health checks** - Comprehensive status endpoints
-- **Performance tracking** - Built-in latency monitoring
+
+Every decorated function exposes `cache_info()`, returning a `CacheInfo` named tuple with
+hit/miss counts, the L1/L2 split, and average backend latency:
+
+```python
+@cache()
+def get_score(x):
+    return x ** 2
+
+get_score(2)
+get_score(2)  # served from cache
+
+info = get_score.cache_info()
+# CacheInfo has 9 fields: hits, misses, l1_hits, l2_hits, maxsize,
+# currsize, l2_avg_latency_ms, last_operation_at, session_id
+assert info.l1_hits + info.l2_hits == info.hits  # every hit is L1 or L2
+```
+
+`maxsize` and `currsize` are always `None` (the cache lives in an external store, not a
+bounded in-process dict); they exist only for `lru_cache` API parity. See the
+[API Reference](docs/api-reference.md#per-function-statistics-via-cache_info) for the full
+field reference and a sample stats endpoint, and the
+[Prometheus Metrics guide](docs/features/prometheus-metrics.md) for metric names and
+exposition setup.
 
 <details>
 <summary><strong>Thread Safety Details</strong></summary>
@@ -327,8 +351,10 @@ def expensive_func(x):
 with ThreadPoolExecutor(max_workers=10) as executor:
     results = list(executor.map(expensive_func, range(100)))
 
-print(expensive_func.cache_info())
-# CacheInfo(hits=90, misses=10, maxsize=None, currsize=10)
+info = expensive_func.cache_info()
+# CacheInfo(hits=..., misses=..., l1_hits=..., l2_hits=...,
+#           maxsize=None, currsize=None, l2_avg_latency_ms=...,
+#           last_operation_at=..., session_id=...)
 ```
 
 </details>

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -786,16 +786,76 @@ def typed_function(data: dict[str, Any]) -> str | int | None:
 
 ## Monitoring and Observability
 
+### Per-function statistics via `cache_info()`
+
+Every decorated function exposes `cache_info()`, modelled on `functools.lru_cache`. It
+returns a `CacheInfo` named tuple with cumulative, per-function statistics — no Prometheus
+scrape or external dependency required. `CacheInfo` is exported from the top-level package
+(`from cachekit import CacheInfo`).
+
+`CacheInfo` has nine fields:
+
+| Field | Type | Meaning |
+|:------|:-----|:--------|
+| `hits` | `int` | Total cache hits (L1 + L2) |
+| `misses` | `int` | Total cache misses |
+| `l1_hits` | `int` | L1 (in-memory) hits only |
+| `l2_hits` | `int` | L2 (backend) hits only |
+| `maxsize` | `int \| None` | Always `None` for external caches |
+| `currsize` | `int \| None` | Always `None` for external caches |
+| `l2_avg_latency_ms` | `float` | Average L2 (backend) latency in milliseconds |
+| `last_operation_at` | `float \| None` | Unix timestamp of the last cache operation, or `None` |
+| `session_id` | `str \| None` | Function-specific session ID for correlation |
+
+The hit counters satisfy the invariant `l1_hits + l2_hits == hits`: every hit is served
+either from the in-memory L1 layer or from the backend L2 layer, never both. `maxsize` and
+`currsize` are kept only for `lru_cache` API parity and are always `None` because the cache
+lives in an external store, not a bounded in-process dict.
+
+Statistics are tracked per decorated function (shared across all calls) and are thread-safe.
+`cache_clear()` resets the counters and rotates `session_id`.
+
+A minimal stats endpoint that surfaces `cache_info()` over HTTP:
+
+```python notest
+from cachekit import cache
+
+@cache(ttl=300)
+def get_user(user_id):
+    return db.query(User).get(user_id)
+
+def cache_stats():
+    """Return per-function cache statistics as a JSON-serializable dict."""
+    info = get_user.cache_info()
+    total = info.hits + info.misses
+    return {
+        "hits": info.hits,
+        "misses": info.misses,
+        "l1_hits": info.l1_hits,
+        "l2_hits": info.l2_hits,
+        "hit_ratio": round(info.hits / total, 4) if total else 0.0,
+        "l2_avg_latency_ms": info.l2_avg_latency_ms,
+        "last_operation_at": info.last_operation_at,
+        "session_id": info.session_id,
+    }
+```
+
 ### Prometheus Metrics
 
-The library exposes comprehensive metrics (enabled by default):
+The library records metrics on the default `prometheus_client` registry (enabled by
+default). **Exposition is the application's responsibility** — cachekit does not start an
+HTTP server or register a `/metrics` route; wire up `prometheus_client` exposition
+(`start_http_server` or `make_wsgi_app`/`make_asgi_app`) in your app. The emitted series
+names carry no `cachekit_` prefix:
 
-- `cachekit_cache_operations_total` - Operation counts by operation, status, serializer, namespace
-- `cachekit_cache_operation_duration_seconds` - Latency histograms with optimized buckets
-- `cachekit_circuit_breaker_state` - Circuit breaker state per namespace (0=closed, 1=open, 2=half-open)
-- `cachekit_connection_pool_utilization` - Pool usage ratio (0.0-1.0)
-- `cachekit_connection_pool_usage` - Detailed pool statistics (created, available, in_use)
-- `cachekit_serialization_fallbacks_total` - Serializer fallback tracking
+- `cache_operations_total` - Operation counter. Labels: `operation`, `namespace`, `success`, `serializer`
+- `redis_cache_operations_total` - Load-control operation counter. Labels: `operation`, `status`, `serializer`, `namespace`
+- `cache_operation_duration_ms` - Operation latency histogram (milliseconds). Labels: `operation`, `namespace`, `serializer`
+- `cache_operation_size_bytes` - Operation payload size histogram (bytes). Labels: `operation`, `namespace`, `serializer`
+- `circuit_breaker_state` - Circuit breaker state gauge (0=CLOSED, 1=OPEN, 2=HALF_OPEN). Labels: `namespace`, `state`
+
+See the [Prometheus Metrics guide](features/prometheus-metrics.md) for exposition setup,
+query examples, and alerting rules.
 
 ### Structured Logging
 
@@ -804,13 +864,6 @@ All operations include structured logging with:
 - Operation context (namespace, cache key, serializer)
 - Performance metrics (duration, cache hit/miss)
 - Error classification and recovery actions
-
-### Health Monitoring
-
-Pre-built Grafana dashboards available in `/monitoring/grafana/`:
-- Cache Overview Dashboard
-- Reliability Metrics Dashboard
-- Performance Analysis Dashboard
 
 ## Best Practices
 

--- a/docs/features/prometheus-metrics.md
+++ b/docs/features/prometheus-metrics.md
@@ -6,87 +6,104 @@
 
 ## TL;DR
 
-cachekit exports Prometheus metrics automatically. No instrumentation code needed. Cache hits/misses/errors tracked per function.
+cachekit records Prometheus metrics for cache operations, latency, payload size, and
+circuit-breaker state. Collection is on by default — no per-call instrumentation code is
+needed. **Exposition is your responsibility**: cachekit does not start an HTTP server or
+register a `/metrics` route. Wire up `prometheus_client` exposition in your app and the
+metrics show up on your existing scrape endpoint.
 
 ```prometheus
-cachekit_cache_hits_total{function="get_user"} 9847
-cachekit_cache_misses_total{function="get_user"} 203
-cachekit_cache_errors_total{function="get_user"} 5
+cache_operations_total{operation="get",namespace="users",success="True",serializer="default"} 9847
+redis_cache_operations_total{operation="get",status="hit",serializer="default",namespace="users"} 9847
 ```
 
 ---
 
 ## Quick Start
 
-Metrics exported automatically:
+Metrics are recorded automatically once a decorated function runs:
 
-```python
+```python notest
 from cachekit import cache
 
-@cache(ttl=300)  # Metrics exported by default
+@cache(ttl=300)  # Metrics recorded by default
 def get_user(user_id):
     return db.query(User).get(user_id)
-
-# Prometheus scrape endpoint picks up metrics automatically
-# No configuration needed
 ```
 
-**Scrape configuration** (prometheus.yml):
+cachekit registers its metrics on the default `prometheus_client` registry. To make them
+scrapeable you must expose that registry yourself — cachekit ships no HTTP server. The two
+common options:
+
+```python notest
+# Option A: dedicated metrics HTTP server (e.g. a worker process or sidecar)
+from prometheus_client import start_http_server
+
+start_http_server(8000)  # serves the default registry at http://0.0.0.0:8000/metrics
+```
+
+```python notest
+# Option B: mount exposition into an existing ASGI/WSGI app (here: a WSGI app)
+from prometheus_client import make_wsgi_app
+from wsgiref.simple_server import make_server
+
+metrics_app = make_wsgi_app()  # serves the default registry
+# mount metrics_app at /metrics in your framework of choice
+make_server("0.0.0.0", 8000, metrics_app).serve_forever()
+```
+
+**Scrape configuration** (prometheus.yml) — point Prometheus at whatever endpoint your app
+exposes:
+
 ```yaml
 scrape_configs:
   - job_name: 'cachekit'
     static_configs:
-      - targets: ['localhost:8000']  # Your app port
-    metrics_path: '/metrics'  # Standard Prometheus endpoint
+      - targets: ['localhost:8000']  # The host:port your app exposes metrics on
+    metrics_path: '/metrics'         # Whatever path you mounted exposition on
 ```
 
 ---
 
 ## Available Metrics
 
-### Counter Metrics (always increasing)
+cachekit emits the following metrics on the default `prometheus_client` registry. The names
+below are the **actual** series names — none carry a `cachekit_` prefix.
+
+### Counters (always increasing)
+
 ```prometheus
-# Cache hit count
-cachekit_cache_hits_total{function="get_user"}
+# Cache operations from the async/sync metrics path.
+# Labels: operation, namespace, success, serializer
+cache_operations_total{operation="get",namespace="users",success="True",serializer="default"}
 
-# Cache miss count
-cachekit_cache_misses_total{function="get_user"}
-
-# Error count (Redis, etc)
-cachekit_cache_errors_total{function="get_user"}
-
-# Circuit breaker events
-cachekit_circuit_breaker_opens_total{function="get_user"}
-cachekit_circuit_breaker_closes_total{function="get_user"}
-
-# Lock events
-cachekit_lock_acquisitions_total{function="get_user"}
-cachekit_lock_timeouts_total{function="get_user"}
+# Cache operations from the backpressure/load-control path.
+# Labels: operation, status, serializer, namespace
+redis_cache_operations_total{operation="get",status="hit",serializer="default",namespace="users"}
 ```
 
-### Histogram Metrics (latency)
+> Hits and misses are not separate series. Compute them from labels — the `success` label
+> on `cache_operations_total` and the `status` label on `redis_cache_operations_total`
+> distinguish hits from misses.
+
+### Histograms (latency and size)
+
 ```prometheus
-# Time to cache hit (L1 + L2)
-cachekit_cache_hit_duration_seconds_bucket{function="get_user",le="0.001"}
-cachekit_cache_hit_duration_seconds_bucket{function="get_user",le="0.01"}
+# Cache operation duration in milliseconds.
+# Labels: operation, namespace, serializer
+cache_operation_duration_ms{operation="get",namespace="users",serializer="default"}
 
-# Time to cache miss + function execution
-cachekit_cache_miss_duration_seconds_bucket{function="get_user",le="1.0"}
-
-# L1 cache hit latency (always fast)
-cachekit_l1_hit_duration_seconds{function="get_user"}
-
-# L2 cache hit latency (Redis roundtrip)
-cachekit_l2_hit_duration_seconds{function="get_user"}
+# Cache operation payload size in bytes.
+# Labels: operation, namespace, serializer
+cache_operation_size_bytes{operation="get",namespace="users",serializer="default"}
 ```
 
-### Gauge Metrics (current state)
-```prometheus
-# Number of items in L1 cache
-cachekit_l1_cache_size{function="get_user"}
+### Gauges (current state)
 
-# Circuit breaker state (0=CLOSED, 1=OPEN, 2=HALF_OPEN)
-cachekit_circuit_breaker_state{function="get_user"}
+```prometheus
+# Circuit breaker state. Numeric value: 0=CLOSED, 1=OPEN, 2=HALF_OPEN.
+# Labels: namespace, state
+circuit_breaker_state{namespace="users",state="open"}
 ```
 
 ---
@@ -94,76 +111,42 @@ cachekit_circuit_breaker_state{function="get_user"}
 ## Query Examples
 
 ### Cache Hit Rate
+
 ```promql
-# Hit rate (percentage)
-100 * sum(rate(cachekit_cache_hits_total[5m]))
-    / (sum(rate(cachekit_cache_hits_total[5m]))
-     + sum(rate(cachekit_cache_misses_total[5m])))
+# Hit rate (percentage) using the success label on cache_operations_total
+100 * sum(rate(cache_operations_total{success="True"}[5m]))
+    / sum(rate(cache_operations_total[5m]))
+```
+
+```promql
+# Hit rate from the load-control path using the status label
+100 * sum(rate(redis_cache_operations_total{status="hit"}[5m]))
+    / sum(rate(redis_cache_operations_total[5m]))
 ```
 
 ### Cache Latency (P99)
+
 ```promql
-# 99th percentile latency for cache hits
+# 99th percentile cache operation duration (milliseconds)
 histogram_quantile(0.99,
-  rate(cachekit_cache_hit_duration_seconds_bucket[5m])
+  rate(cache_operation_duration_ms_bucket[5m])
 )
 ```
 
-### Circuit Breaker Trips
+### Payload Size (P99)
+
 ```promql
-# How often circuit breaker opens
-rate(cachekit_circuit_breaker_opens_total[5m])
+# 99th percentile cache payload size (bytes)
+histogram_quantile(0.99,
+  rate(cache_operation_size_bytes_bucket[5m])
+)
 ```
 
-### L1 vs L2 Performance
+### Circuit Breaker State
+
 ```promql
-# Average L1 latency
-avg(cachekit_l1_hit_duration_seconds)
-
-# Average L2 latency
-avg(cachekit_l2_hit_duration_seconds)
-
-# Ratio (L2 should be 40-100x slower)
-avg(cachekit_l2_hit_duration_seconds)
-  / avg(cachekit_l1_hit_duration_seconds)
-```
-
-### Lock Contention
-```promql
-# Average pods waiting for lock
-avg(rate(cachekit_lock_wait_duration_seconds[5m]))
-```
-
----
-
-## Grafana Dashboard Example
-
-```json
-{
-  "dashboard": {
-    "title": "cachekit Metrics",
-    "panels": [
-      {
-        "title": "Cache Hit Rate",
-        "targets": [{
-          "expr": "100 * sum(rate(cachekit_cache_hits_total[5m])) / (sum(rate(cachekit_cache_hits_total[5m])) + sum(rate(cachekit_cache_misses_total[5m])))"
-        }]
-      },
-      {
-        "title": "Cache Latency (P99)",
-        "targets": [{
-          "expr": "histogram_quantile(0.99, rate(cachekit_cache_hit_duration_seconds_bucket[5m]))"
-        }]
-      },
-      {
-        "title": "Circuit Breaker State",
-        "targets": [{
-          "expr": "cachekit_circuit_breaker_state"
-        }]
-      }
-    ]
-  }
-}
+# Current circuit breaker state per namespace (0=CLOSED, 1=OPEN, 2=HALF_OPEN)
+circuit_breaker_state
 ```
 
 ---
@@ -171,32 +154,25 @@ avg(rate(cachekit_lock_wait_duration_seconds[5m]))
 ## Alerting Examples
 
 ### Alert: Low Cache Hit Rate
+
 ```yaml
 - alert: LowCacheHitRate
   expr: |
-    100 * sum(rate(cachekit_cache_hits_total[5m]))
-        / (sum(rate(cachekit_cache_hits_total[5m]))
-         + sum(rate(cachekit_cache_misses_total[5m])))
+    100 * sum(rate(cache_operations_total{success="True"}[5m]))
+        / sum(rate(cache_operations_total[5m]))
     < 50  # Hit rate below 50%
   annotations:
     summary: "Cache hit rate is low (< 50%)"
 ```
 
 ### Alert: Circuit Breaker Open
+
 ```yaml
 - alert: CircuitBreakerOpen
-  expr: cachekit_circuit_breaker_state > 0  # Not CLOSED
+  expr: circuit_breaker_state > 0  # Not CLOSED
   for: 1m
   annotations:
     summary: "Cache circuit breaker is open"
-```
-
-### Alert: Lock Timeouts
-```yaml
-- alert: CacheLockTimeouts
-  expr: increase(cachekit_lock_timeouts_total[5m]) > 10
-  annotations:
-    summary: "Cache lock timeouts occurring"
 ```
 
 ---
@@ -204,6 +180,11 @@ avg(rate(cachekit_lock_wait_duration_seconds[5m]))
 ## Configuration
 
 ### Enable/Disable Metrics
+
+Metric collection is controlled by `MonitoringConfig.enable_prometheus_metrics` (default:
+`True`). Disabling it stops cachekit from recording series; it has no effect on exposition,
+which your app owns regardless.
+
 ```python notest
 from cachekit import cache
 from cachekit.config.nested import MonitoringConfig
@@ -217,6 +198,7 @@ def operation(x):
 ```
 
 ### Disable Metrics
+
 ```python notest
 from cachekit import cache
 from cachekit.config.nested import MonitoringConfig
@@ -230,6 +212,7 @@ def operation(x):
 ```
 
 ### Disable All Observability
+
 ```python notest
 from cachekit import cache
 from cachekit.config.nested import MonitoringConfig
@@ -249,6 +232,16 @@ def operation(x):
 
 ---
 
+## Per-Function Statistics
+
+For lightweight, in-process counters that do not require a Prometheus scrape, every
+decorated function exposes `cache_info()` (modelled on `functools.lru_cache`). It returns a
+`CacheInfo` named tuple with hit/miss counts, the L1/L2 split, and average L2 latency. See
+the [API Reference](../api-reference.md#per-function-statistics-via-cache_info) for the full
+field list and an example stats endpoint.
+
+---
+
 ## Performance Impact
 
 Metrics collection is minimal overhead:
@@ -258,41 +251,29 @@ Metrics collection is minimal overhead:
 
 ---
 
-## Integration with Other Features
-
-**Metrics + Circuit Breaker**:
-```prometheus
-cachekit_circuit_breaker_opens_total  # How many times CB opened
-cachekit_circuit_breaker_state  # Current state
-```
-
-**Metrics + Distributed Locking**:
-```prometheus
-cachekit_lock_acquisitions_total  # Lock wins
-cachekit_lock_timeouts_total  # Lock failures
-cachekit_lock_wait_duration_seconds  # How long pods waited
-```
-
----
-
 ## Troubleshooting
 
-**Q: Metrics endpoint not responding**
-A: Check METRICS_ENABLED=true, metrics port is exposed
+**Q: My `/metrics` endpoint returns nothing for cachekit**
+A: cachekit does not expose metrics for you. Confirm your app starts
+`prometheus_client` exposition (`start_http_server` or `make_wsgi_app`/`make_asgi_app`) on
+the **default** registry, and that at least one decorated function has run — series are
+created lazily on first use.
 
 **Q: Hit rate always 0**
-A: Check if function is actually being called, L1/L2 cache working
+A: Check that the function is actually being called and that L1/L2 caching is working.
+Remember hit/miss is derived from labels (`success` / `status`), not from separate series.
 
 **Q: Metrics growing unbounded**
-A: Prometheus retention is configurable (default 15 days)
+A: Prometheus retention is configurable (default 15 days). Keep label cardinality bounded —
+avoid high-cardinality `namespace` values.
 
 ---
 
 ## See Also
 
-- [Circuit Breaker](circuit-breaker.md) - Monitored by metrics
-- [Distributed Locking](distributed-locking.md) - Lock metrics tracked
-- [Prometheus Metrics Integration](../getting-started.md#prometheus)
+- [API Reference – Monitoring and Observability](../api-reference.md#monitoring-and-observability) - Full metric list and `cache_info()`
+- [Circuit Breaker](circuit-breaker.md) - Source of `circuit_breaker_state`
+- [Distributed Locking](distributed-locking.md) - Multi-pod safety
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation-accuracy fixes for the observability surface:

- **`cache_info()` / `CacheInfo`** is implemented and exported but was barely documented. Added a "Per-function statistics via `cache_info()`" subsection to the API reference covering all nine `CacheInfo` fields (`hits`, `misses`, `l1_hits`, `l2_hits`, `maxsize`, `currsize`, `l2_avg_latency_ms`, `last_operation_at`, `session_id`), the `l1_hits + l2_hits == hits` invariant, and a minimal stats-endpoint example. Surfaced it in the README out of the collapsed details block and **fixed the stale four-field example** (`CacheInfo(hits=90, misses=10, maxsize=None, currsize=10)`) that predates the L1/L2 split.
- **Prometheus docs were factually wrong.** They cited fictional `cachekit_`-prefixed metric names that do not exist anywhere in `src/`, claimed metrics are auto-exported on a `/metrics` endpoint with no configuration, and referenced a `/monitoring/grafana/` directory that does not exist. Replaced the metric names with the real emitted series, removed the false auto-export claim, and deleted the Grafana directory reference.

## Why

Wrong observability docs are worse than missing ones: users wire dashboards and alerts against metric names that will never appear, and never discover the per-function `cache_info()` API because the README hid it inside a collapsed block with a stale example. The corrected docs reflect what the code actually emits.

The real series names (verified against `src/`):

| Metric | Type | Source |
|---|---|---|
| `cache_operations_total` | Counter | `reliability/async_metrics.py` |
| `redis_cache_operations_total` | Counter | `reliability/load_control.py` |
| `cache_operation_duration_ms` | Histogram | `reliability/async_metrics.py` |
| `cache_operation_size_bytes` | Histogram | `reliability/async_metrics.py` |
| `circuit_breaker_state` | Gauge | `reliability/async_metrics.py`, `reliability/metrics_collection.py` |

None carry a `cachekit_` prefix. The docs now also state plainly that cachekit only *records* metrics on the default `prometheus_client` registry — the application must wire exposition itself.

## Scope

Docs only — no code or behavior changes. The real metric names are left **unchanged** (renaming them would be a breaking change, explicitly out of scope). The bundled request for a one-call `enable_prometheus_metrics()` helper plus `CACHEKIT_PROMETHEUS_ENABLED` env var is split out to #146, where it needs an API decision (it overlaps the existing-but-renamed metrics path).

## Verification

- `uv run pytest tests/docs/ -q` → 70 passed (ground-truth doc drift suite).
- `uv run pytest --markdown-docs docs/` → 126 passed (executable markdown examples, including the edited API reference and Prometheus guide).
- Confirmed every metric name written into the docs appears in `src/`, and that no `cachekit_`-prefixed metric names, `/monitoring/grafana/` references, or stale four-field `CacheInfo` examples remain.

Closes #42