### PR TITLE
ci: auto-sync lockfiles in release-please PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,6 +30,10 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
+      # prs_created is "true" when a release PR was opened or updated this run.
+      # pr is the JSON-encoded PullRequest object; we read .headBranchName from it.
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      pr: ${{ steps.release.outputs.pr }}
     steps:
       # Use GitHub App for token vending (avoids branch protection issues with GITHUB_TOKEN)
       # If APP_ID/APP_PRIVATE_KEY not set, falls back to GITHUB_TOKEN
@@ -48,6 +52,62 @@ jobs:
           manifest-file: .release-please-manifest.json
           config-file: release-please-config.json
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+  sync-lockfiles:
+    name: Sync lockfiles in release PR
+    needs: release-please
+    # Only run when release-please opened or updated a release PR. The lockfiles
+    # (uv.lock, root Cargo.lock) are not touched by release-please, so they drift
+    # behind the version bumps in pyproject.toml / __init__.py / Cargo.toml unless
+    # we regenerate and commit them onto the release PR branch.
+    if: ${{ needs.release-please.outputs.prs_created == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      # Re-mint the App token in this job: step outputs are job-scoped, so the
+      # token from the release-please job is not visible here. The App token lets
+      # the push below re-trigger required checks on the PR (pushes made with the
+      # default GITHUB_TOKEN do not trigger further workflow runs).
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        if: ${{ vars.USE_APP_TOKEN == 'true' }}
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout release PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      # Regenerate the lockfiles from the bumped manifests. Both run from the repo
+      # root: uv.lock and Cargo.lock are the workspace locks (there is no rust/Cargo.lock).
+      - name: Sync uv lockfile
+        run: uv lock
+
+      - name: Sync Cargo lockfile
+        run: cargo update -p cachekit-rs
+
+      - name: Commit and push lockfile changes
+        env:
+          BRANCH: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock Cargo.lock
+          if git diff --staged --quiet; then
+            echo "Lockfiles already in sync; nothing to commit."
+            exit 0
+          fi
+          git commit -m "chore: sync lockfiles with release"
+          git push origin "HEAD:${BRANCH}"
 
   validate-inputs:
     name: Validate Release Inputs


### PR DESCRIPTION
## What

Adds a `sync-lockfiles` job to `.github/workflows/release-please.yml` that regenerates and commits the workspace lockfiles onto the release-please PR branch whenever a release PR is opened or updated.

## Why

release-please bumps versions in `pyproject.toml`, `src/cachekit/__init__.py`, and `rust/Cargo.toml`, but it never touches `uv.lock` or the root `Cargo.lock`. As a result the lockfiles drift behind the manifests on every release PR, and the drift only surfaces later as a confusing "lockfile out of date" failure. The maintainer chose to auto-update the lockfiles in the release PR itself, using the App token the workflow already vends.

## How it works

- Two new outputs are surfaced on the `release-please` job: `prs_created` (the documented v4 signal that a release PR was opened/updated) and `pr` (the JSON-encoded PullRequest object).
- The new job is gated on `needs.release-please.outputs.prs_created == 'true'` and:
  1. Re-mints the GitHub App token (step outputs are job-scoped, so it is not visible from the `release-please` job). The App token is used as the checkout `token` so the subsequent push re-triggers required checks on the PR — pushes made with the default `GITHUB_TOKEN` do not trigger further workflow runs.
  2. Checks out the release PR head branch via `fromJSON(needs.release-please.outputs.pr).headBranchName`.
  3. Installs `uv` (`astral-sh/setup-uv`, SHA-pinned) and a Rust toolchain via `rustup` (matching the existing convention already used in this file's `attest` job).
  4. Runs `uv lock` and `cargo update -p cachekit-rs` from the repo root. Both lockfiles are workspace-level at the repo root — there is no `rust/Cargo.lock`, and the Rust package is `cachekit-rs`.
  5. Commits `chore: sync lockfiles with release` and pushes to the PR branch only if the lockfiles actually changed.

## Verification

This change only runs during a real release-please run, which cannot be exercised locally. Statically verified:

- `actionlint .github/workflows/release-please.yml` — passes with no findings (also confirmed by the repo's own pre-commit "Lint GitHub Actions workflow files" hook).
- YAML parses cleanly (`python -c "import yaml; yaml.safe_load(...)"`).
- Every referenced step id (`app-token`, `release`) and output name (`prs_created`, `pr`) is confirmed to exist in the file; `prs_created`/`pr` are the actual outputs exposed by `googleapis/release-please-action@v4`.
- New actions are SHA-pinned with `# vN` comments per repo convention.

Full behaviour can only be confirmed on the next release-please run.

Closes #9