### PR TITLE
feat: honor user serializer under encryption via cross_sdk_compatible marker

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "src/cachekit/cache_handler.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 251
+        "line_number": 256
       }
     ],
     "src/cachekit/config/decorator.py": [
@@ -425,5 +425,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-06T12:52:34Z"
+  "generated_at": "2026-06-06T14:01:35Z"
 }

--- a/src/cachekit/cache_handler.py
+++ b/src/cachekit/cache_handler.py
@@ -27,6 +27,11 @@ from cachekit.serializers.wrapper import SerializationWrapper
 if TYPE_CHECKING:
     from cachekit.serializers.base import SerializerProtocol
 
+# Serializer string names whose wire format is language-agnostic and therefore safe to
+# use under encryption (Issue #134). 'auto' is intentionally excluded — it emits
+# Python-specific type tags that no other-language SDK can decode.
+CROSS_SDK_SERIALIZER_NAMES = ("default", "std", "standard", "orjson", "arrow")
+
 # Global DI container instance with default registrations
 container = DIContainer()
 container.register(LoggerProvider, DefaultLoggerProvider)
@@ -342,17 +347,27 @@ class CacheSerializationHandler:
                     "Choose multi-tenant (tenant_extractor) OR single-tenant (single_tenant_mode=True)."
                 )
 
-            # Encryption requires StandardSerializer (MessagePack) for cross-SDK interop
-            if isinstance(serializer_name, str) and serializer_name not in ("default", "std", "standard"):
+            # Issue #134: Encryption requires a cross-SDK-compatible serializer so the
+            # encrypted bytes remain decodable by other-language SDKs. The user's
+            # serializer is threaded into EncryptionWrapper (see
+            # _get_cached_encryption_wrapper); it is NOT silently replaced. We therefore
+            # allow any serializer that produces a language-agnostic wire format and reject
+            # the rest (notably 'auto' and unmarked custom instances) with a clear error.
+            if isinstance(serializer_name, str):
+                if serializer_name not in CROSS_SDK_SERIALIZER_NAMES:
+                    raise ConfigurationError(
+                        f"Encryption requires a cross-SDK-compatible serializer for cross-language "
+                        f"interop, got serializer='{serializer_name}'. Allowed under encryption: "
+                        f"{', '.join(CROSS_SDK_SERIALIZER_NAMES)}. The 'auto' serializer emits "
+                        f"Python-specific types that other SDKs cannot decode, so it cannot be used "
+                        f"with encryption."
+                    )
+            elif not getattr(type(serializer_name), "cross_sdk_compatible", False):
                 raise ConfigurationError(
-                    f"Encryption requires 'default' serializer for cross-language interop, "
-                    f"got serializer='{serializer_name}'. EncryptionWrapper uses StandardSerializer "
-                    f"(MessagePack) internally for cross-SDK compatibility."
-                )
-            elif not isinstance(serializer_name, str):
-                raise ConfigurationError(
-                    "Encryption requires 'default' serializer for cross-language interop. "
-                    "Custom serializer instances cannot be used with encryption."
+                    f"Encryption requires a cross-SDK-compatible serializer for cross-language interop. "
+                    f"The serializer instance '{type(serializer_name).__name__}' does not declare "
+                    f"cross_sdk_compatible=True. Custom serializers used with encryption must set the "
+                    f"cross_sdk_compatible ClassVar to True and guarantee a language-agnostic wire format."
                 )
 
             # Generate deterministic deployment UUID for single-tenant mode
@@ -489,7 +504,18 @@ class CacheSerializationHandler:
 
             # Convert master_key from hex string to bytes if provided
             master_key_bytes = bytes.fromhex(self.master_key) if self.master_key else None
-            wrapper = EncryptionWrapper(tenant_id=tenant_id, master_key=master_key_bytes)
+
+            # Issue #134: thread the user's base serializer into the wrapper so a
+            # cross-SDK-compatible serializer (Arrow/orjson) is actually used under
+            # encryption instead of being silently replaced by StandardSerializer.
+            # The base serializer is fixed per handler instance, so the per-tenant
+            # cache key (tenant_id) remains correct — every wrapper for this handler
+            # wraps the same _base_serializer.
+            wrapper = EncryptionWrapper(
+                serializer=self._base_serializer,
+                tenant_id=tenant_id,
+                master_key=master_key_bytes,
+            )
 
             # Enforce LRU cache size limit
             if len(self._encryption_wrapper_cache) >= self._encryption_cache_maxsize:

--- a/src/cachekit/serializers/__init__.py
+++ b/src/cachekit/serializers/__init__.py
@@ -8,6 +8,7 @@ from cachekit._rust_serializer import ByteStorage
 
 from .auto_serializer import AutoSerializer
 from .base import (
+    CrossSDKSerializerProtocol,
     SerializationError,
     SerializationFormat,
     SerializationMetadata,
@@ -207,6 +208,7 @@ __all__ = [
     "OrjsonSerializer",
     "StandardSerializer",
     # Base types
+    "CrossSDKSerializerProtocol",
     "SerializationError",
     "SerializationFormat",
     "SerializationMetadata",

--- a/src/cachekit/serializers/arrow_serializer.py
+++ b/src/cachekit/serializers/arrow_serializer.py
@@ -22,7 +22,7 @@ Type checker cannot statically verify optional imports; suppressed via pyright c
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from .base import SerializationError, SerializationFormat, SerializationMetadata
 
@@ -108,6 +108,9 @@ class ArrowSerializer:
         Traceback (most recent call last):
         SerializationError: Checksum validation failed - data corruption detected
     """
+
+    # Apache Arrow IPC is a cross-language columnar format (Python, R, Julia, Rust) — safe under encryption.
+    cross_sdk_compatible: ClassVar[bool] = True
 
     def __init__(self, return_format: str = "pandas", enable_integrity_checking: bool = True):
         """Initialize ArrowSerializer.

--- a/src/cachekit/serializers/auto_serializer.py
+++ b/src/cachekit/serializers/auto_serializer.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import logging
 from datetime import date, datetime, time
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 from uuid import UUID
 
 import msgpack
@@ -351,6 +351,10 @@ class AutoSerializer:
         >>> fast_serializer.deserialize(data)
         {'fast': True}
     """
+
+    # AutoSerializer emits Python-specific type tags (set, frozenset, UUID, tuple) that no
+    # other-language SDK can decode — single-SDK only, so it is rejected under encryption.
+    cross_sdk_compatible: ClassVar[bool] = False
 
     def __init__(
         self,

--- a/src/cachekit/serializers/base.py
+++ b/src/cachekit/serializers/base.py
@@ -6,7 +6,7 @@ This module contains shared types and utilities used by all serializers.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, ClassVar, Protocol, runtime_checkable
 
 
 @runtime_checkable
@@ -19,6 +19,27 @@ class SerializerProtocol(Protocol):
 
     The protocol is runtime-checkable to enable isinstance() validation
     without requiring explicit inheritance.
+
+    Cross-SDK contract (``cross_sdk_compatible``):
+        Serializers carry a class-level ``cross_sdk_compatible: bool`` attribute
+        that declares whether their wire format is language-agnostic (readable by
+        other-language CacheKit SDKs). It governs whether the serializer may be
+        used under encryption — see ``EncryptionWrapper`` and the validation in
+        ``CacheSerializationHandler.__init__``:
+
+        - ``True``  (StandardSerializer/MessagePack, OrjsonSerializer/JSON,
+          ArrowSerializer/Arrow IPC): the user's serializer is threaded into the
+          EncryptionWrapper and used as-is under encryption.
+        - ``False`` (AutoSerializer, which emits Python-specific type tags; and any
+          serializer that does not declare the flag): single-SDK only, so combining
+          it with encryption is rejected at decoration time.
+
+        This attribute is intentionally NOT part of the runtime-checkable structural
+        set: ``runtime_checkable`` would otherwise force every method-only custom
+        serializer to also declare it, breaking ``isinstance(x, SerializerProtocol)``
+        on the plaintext path across Python 3.10-3.14. It is enforced for type
+        checkers via ``CrossSDKSerializerProtocol`` below, and read at runtime via
+        ``getattr(type(s), "cross_sdk_compatible", False)`` (unmarked == single-SDK).
 
     Examples:
         >>> class MySerializer:
@@ -98,6 +119,23 @@ class SerializerProtocol(Protocol):
             True
         """
         ...
+
+
+class CrossSDKSerializerProtocol(SerializerProtocol, Protocol):
+    """SerializerProtocol plus the ``cross_sdk_compatible`` class attribute.
+
+    Static-typing-only extension of :class:`SerializerProtocol`. It is deliberately
+    NOT ``@runtime_checkable``: the marker is enforced by type checkers (so the core
+    serializers and any opt-in custom serializer must declare the flag), while the
+    runtime ``isinstance(x, SerializerProtocol)`` check stays method-only and never
+    rejects a valid method-only custom serializer just because it omits the flag.
+
+    At runtime the flag is read defensively via
+    ``getattr(type(serializer), "cross_sdk_compatible", False)``; an unmarked
+    serializer is treated as single-SDK (not safe under encryption).
+    """
+
+    cross_sdk_compatible: ClassVar[bool]
 
 
 class SerializerType(str, Enum):

--- a/src/cachekit/serializers/orjson_serializer.py
+++ b/src/cachekit/serializers/orjson_serializer.py
@@ -12,7 +12,7 @@ Integrity Protection:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
 import orjson
 import xxhash
@@ -73,6 +73,9 @@ class OrjsonSerializer:
         Traceback (most recent call last):
         SerializationError: Checksum validation failed - data corruption detected
     """
+
+    # orjson emits standard JSON — a language-agnostic wire format, safe under encryption.
+    cross_sdk_compatible: ClassVar[bool] = True
 
     def __init__(self, option: int = orjson.OPT_SORT_KEYS, enable_integrity_checking: bool = True):
         """Initialize OrjsonSerializer.

--- a/src/cachekit/serializers/standard_serializer.py
+++ b/src/cachekit/serializers/standard_serializer.py
@@ -21,7 +21,7 @@ Security: Uses strict isinstance() checks (no hasattr()) to prevent arbitrary co
 from __future__ import annotations
 
 from datetime import date, datetime, time
-from typing import Any
+from typing import Any, ClassVar
 
 import msgpack
 
@@ -225,6 +225,9 @@ class StandardSerializer:
         Traceback (most recent call last):
         TypeError: StandardSerializer does not support NumPy arrays...
     """
+
+    # MessagePack is a language-agnostic wire format — safe under encryption for cross-SDK reads.
+    cross_sdk_compatible: ClassVar[bool] = True
 
     def __init__(self, enable_integrity_checking: bool = True):
         """Initialize StandardSerializer.

--- a/tests/critical/test_encryption_integration.py
+++ b/tests/critical/test_encryption_integration.py
@@ -343,3 +343,65 @@ class TestEncryptionIntegration(RedisIsolationMixin):
         result3 = get_data(1)
         assert result3["call"] == 2
         assert call_count == 2
+
+    def test_encrypted_arrow_dataframe_uses_arrow_not_messagepack(self):
+        """CRITICAL (Issue #134): Arrow DataFrame must flow through the encryption path as Arrow.
+
+        Before the fix, EncryptionWrapper was built without the user's serializer and
+        silently substituted StandardSerializer (MessagePack), which cannot round-trip a
+        DataFrame. This asserts:
+        1. The cached EncryptionWrapper wraps the user's ArrowSerializer.
+        2. A DataFrame survives encrypt -> store-in-Redis -> retrieve -> decrypt unchanged.
+        3. The raw bytes in Redis are ciphertext (no plaintext column values).
+        """
+        import pandas as pd
+
+        from cachekit.cache_handler import CacheSerializationHandler
+        from cachekit.config.nested import EncryptionConfig, L1CacheConfig
+        from cachekit.serializers.arrow_serializer import ArrowSerializer
+        from cachekit.serializers.base import SerializationFormat
+
+        # Direct handler-level invariant: wrapper wraps Arrow, metadata carries Arrow format.
+        deployment_uuid = "00000000-0000-0000-0000-000000000134"
+        handler = CacheSerializationHandler(
+            serializer_name=ArrowSerializer(),
+            encryption=True,
+            single_tenant_mode=True,
+            deployment_uuid=deployment_uuid,
+            master_key="a" * 64,
+        )
+        wrapper = handler._get_cached_encryption_wrapper(deployment_uuid)
+        assert type(wrapper.serializer).__name__ == "ArrowSerializer", (
+            "EncryptionWrapper must wrap the user's ArrowSerializer under encryption, not MessagePack"
+        )
+        sentinel_df = pd.DataFrame({"col": [1, 2, 3]})
+        _, meta = wrapper.serialize(sentinel_df, cache_key="df:sentinel")
+        assert meta.encrypted is True
+        assert meta.format == SerializationFormat.ARROW
+
+        # End-to-end via the decorator + Redis (L1 disabled so we exercise L2 decrypt).
+        @cache(
+            ttl=300,
+            namespace="enc_arrow_crit",
+            serializer=ArrowSerializer(),
+            encryption=EncryptionConfig(enabled=True, master_key="a" * 64, single_tenant_mode=True),
+            l1=L1CacheConfig(enabled=False),
+        )
+        def load_balances(account: str) -> pd.DataFrame:
+            return pd.DataFrame({"account": [account], "balance": [424242.0]})
+
+        df1 = load_balances("acct-1")
+        assert df1["balance"].iloc[0] == 424242.0
+
+        # Raw Redis bytes must be ciphertext, not the plaintext column value.
+        key_gen = CacheKeyGenerator()
+        cache_key = key_gen.generate_key(load_balances, ("acct-1",), {}, "enc_arrow_crit")
+        raw = self.redis_client.get(self.get_scoped_key(cache_key))
+        assert raw is not None, "Encrypted Arrow data should be stored in Redis"
+        assert b"424242" not in raw, "Balance must NOT appear in plaintext in Redis"
+        assert b"acct-1" not in raw, "Account id must NOT appear in plaintext in Redis"
+
+        # Cache hit decrypts back to the exact DataFrame (proves Arrow, not MessagePack).
+        df2 = load_balances("acct-1")
+        assert isinstance(df2, pd.DataFrame)
+        pd.testing.assert_frame_equal(df2, df1)

--- a/tests/integration/test_serializer_integration.py
+++ b/tests/integration/test_serializer_integration.py
@@ -241,15 +241,113 @@ class TestSerializerGracefulDegradation:
         assert call_count == 2  # Function executed again (no cache)
 
 
-# TestSerializerWithEncryptionInProduction was removed: the tests combined
-# `@cache(serializer=ArrowSerializer())` with `CACHEKIT_MASTER_KEY` to assert that
-# Arrow encoding flows through the encryption path. That combination was never
-# end-to-end functional — cache_handler.py creates `EncryptionWrapper` without
-# passing the user's serializer, so the wrapper silently fell back to
-# StandardSerializer (MessagePack), not Arrow. The v0.6.0 cross-SDK rule
-# (cache_handler.py:351-362) made that silent substitution loud by rejecting
-# the configuration outright.
-#
-# Making this combination actually work requires threading the user's
-# serializer into EncryptionWrapper, marking serializers as cross-SDK
-# compatible, and updating strategy/saas-protocol-v1.0.md. Tracked separately.
+@pytest.mark.integration
+class TestSerializerWithEncryptionInProduction:
+    """Serializer + encryption integration (Issue #134).
+
+    Re-added after PR #133 removed the original variants. Those tests combined
+    ``@cache(serializer=ArrowSerializer())`` with ``CACHEKIT_MASTER_KEY`` and asserted
+    Arrow encoding flowed through the encryption path — it never did, because
+    ``CacheSerializationHandler._get_cached_encryption_wrapper`` built the
+    EncryptionWrapper WITHOUT the user's serializer, so it silently fell back to
+    StandardSerializer (MessagePack). Issue #134 threads the user's serializer into
+    the wrapper and adds the ``cross_sdk_compatible`` marker. These tests lock in the
+    fix: the user's serializer must actually be used under encryption.
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_encryption(self):
+        """Set up encryption master key and reset the settings singleton each side."""
+        from cachekit.config.singleton import reset_settings
+
+        original_master_key = os.environ.get("CACHEKIT_MASTER_KEY")
+        os.environ["CACHEKIT_MASTER_KEY"] = "a" * 64  # 32 bytes hex
+        reset_settings()
+
+        yield
+
+        if original_master_key is not None:
+            os.environ["CACHEKIT_MASTER_KEY"] = original_master_key
+        else:
+            os.environ.pop("CACHEKIT_MASTER_KEY", None)
+        reset_settings()
+
+    def test_arrow_dataframe_encrypt_decrypt_roundtrip(self, redis_isolated):
+        """Arrow DataFrame survives an encrypt -> store -> retrieve -> decrypt roundtrip.
+
+        REGRESSION (Issue #134): before the fix this silently substituted MessagePack,
+        which cannot round-trip a DataFrame, so the cache hit would not equal the source.
+        """
+        call_count = 0
+
+        @cache(ttl=300, serializer=ArrowSerializer(), namespace="enc_arrow_rt")
+        def load_data(user_id: str) -> pd.DataFrame:
+            nonlocal call_count
+            call_count += 1
+            return pd.DataFrame({"user_id": [user_id], "balance": [call_count * 1000.0]})
+
+        # First call - cache miss (serialize+encrypt path)
+        df1 = load_data("user-123")
+        assert call_count == 1
+        assert df1["balance"].iloc[0] == 1000.0
+
+        # Cache entry exists in Redis
+        keys = redis_isolated.keys("*")
+        assert len(keys) > 0
+
+        # Second call - cache hit (retrieve+decrypt path), must equal original DataFrame
+        df2 = load_data("user-123")
+        assert call_count == 1, "Expected cache hit; function should not run again"
+        assert isinstance(df2, pd.DataFrame)
+        pd.testing.assert_frame_equal(df2, df1)
+
+    def test_encrypted_arrow_uses_arrow_not_messagepack(self, redis_isolated):
+        """The EncryptionWrapper must wrap the user's ArrowSerializer, not StandardSerializer.
+
+        This is the core assertion for Issue #134: assert the wrapper's base serializer
+        is the user's Arrow serializer and that the produced metadata carries the Arrow
+        wire format (not MessagePack).
+        """
+        from cachekit.cache_handler import CacheSerializationHandler
+        from cachekit.serializers.arrow_serializer import ArrowSerializer
+        from cachekit.serializers.base import SerializationFormat
+
+        deployment_uuid = "00000000-0000-0000-0000-000000000134"
+        handler = CacheSerializationHandler(
+            serializer_name=ArrowSerializer(),
+            encryption=True,
+            single_tenant_mode=True,
+            deployment_uuid=deployment_uuid,
+            master_key="a" * 64,
+        )
+
+        wrapper = handler._get_cached_encryption_wrapper(deployment_uuid)
+        assert type(wrapper.serializer).__name__ == "ArrowSerializer", (
+            "EncryptionWrapper must wrap the user's ArrowSerializer, not fall back to StandardSerializer"
+        )
+
+        df = pd.DataFrame({"col": [1, 2, 3], "val": [1.5, 2.5, 3.5]})
+        encrypted, metadata = wrapper.serialize(df, cache_key="data:df")
+
+        assert metadata.encrypted is True
+        assert metadata.format == SerializationFormat.ARROW, (
+            f"Encrypted data must carry the Arrow wire format, got {metadata.format}"
+        )
+
+        decrypted = wrapper.deserialize(encrypted, metadata, cache_key="data:df")
+        assert isinstance(decrypted, pd.DataFrame)
+        pd.testing.assert_frame_equal(decrypted, df)
+
+    def test_dataframe_index_preserved_with_encrypted_arrow_serializer(self, redis_isolated):
+        """DataFrame index is preserved through the encrypted Arrow path end-to-end."""
+
+        @cache(ttl=300, serializer=ArrowSerializer(), namespace="enc_arrow_idx")
+        def get_indexed_data() -> pd.DataFrame:
+            return pd.DataFrame({"value": [10, 20, 30]}, index=["a", "b", "c"])
+
+        df1 = get_indexed_data()
+        assert list(df1.index) == ["a", "b", "c"]
+
+        df2 = get_indexed_data()
+        pd.testing.assert_frame_equal(df2, df1)
+        assert list(df2.index) == ["a", "b", "c"]

--- a/tests/unit/test_encryption_security_invariants.py
+++ b/tests/unit/test_encryption_security_invariants.py
@@ -88,25 +88,92 @@ class TestEncryptionWrapperExplicitSerializer:
 
 
 class TestCacheSerializationHandlerEncryptionSerializerValidation:
-    """Cover ConfigurationError branches when encryption=True with non-default serializers."""
+    """Cover validation branches when encryption=True (Issue #134 cross-SDK contract).
 
-    def test_string_non_default_serializer_raises(self):
-        """String serializer name other than default/std/standard raises ConfigurationError."""
-        with pytest.raises(ConfigurationError, match="cross-language interop"):
-            CacheSerializationHandler(
+    Under the cross-SDK contract, encryption ALLOWS any serializer that produces a
+    language-agnostic wire format (default/std/standard/orjson/arrow strings and
+    instances marked cross_sdk_compatible=True), and REJECTS single-SDK serializers
+    ('auto' and unmarked custom instances) so the encrypted bytes stay decodable by
+    other-language SDKs.
+    """
+
+    def test_auto_string_serializer_raises(self, monkeypatch):
+        """String serializer 'auto' (single-SDK) raises ConfigurationError under encryption."""
+        monkeypatch.setenv("CACHEKIT_MASTER_KEY", "a" * 64)
+        from cachekit.config.singleton import reset_settings
+
+        reset_settings()
+        try:
+            with pytest.raises(ConfigurationError, match="cross-SDK-compatible"):
+                CacheSerializationHandler(
+                    serializer_name="auto",
+                    encryption=True,
+                    single_tenant_mode=True,
+                )
+        finally:
+            reset_settings()
+
+    def test_unmarked_custom_instance_serializer_raises(self, monkeypatch):
+        """Custom serializer instance without cross_sdk_compatible=True raises under encryption."""
+        monkeypatch.setenv("CACHEKIT_MASTER_KEY", "a" * 64)
+        from cachekit.config.singleton import reset_settings
+
+        class UnmarkedSerializer:
+            # No cross_sdk_compatible attribute -> treated as single-SDK
+            def serialize(self, obj):
+                return b"", None
+
+            def deserialize(self, data, metadata=None):
+                return None
+
+        reset_settings()
+        try:
+            with pytest.raises(ConfigurationError, match="cross_sdk_compatible"):
+                CacheSerializationHandler(
+                    serializer_name=UnmarkedSerializer(),
+                    encryption=True,
+                    single_tenant_mode=True,
+                )
+        finally:
+            reset_settings()
+
+    def test_orjson_string_accepted_with_encryption(self, monkeypatch):
+        """String serializer 'orjson' (cross-SDK) is accepted under encryption (Issue #134)."""
+        monkeypatch.setenv("CACHEKIT_MASTER_KEY", "a" * 64)
+        from cachekit.config.singleton import reset_settings
+
+        reset_settings()
+        try:
+            handler = CacheSerializationHandler(
                 serializer_name="orjson",
                 encryption=True,
                 single_tenant_mode=True,
             )
+            assert handler.encryption is True
+        finally:
+            reset_settings()
 
-    def test_protocol_instance_serializer_raises(self):
-        """Protocol instance as serializer raises ConfigurationError when encryption=True."""
-        with pytest.raises(ConfigurationError, match="cross-language interop"):
-            CacheSerializationHandler(
-                serializer_name=OrjsonSerializer(),
+    def test_cross_sdk_instance_accepted_and_threaded_into_wrapper(self, monkeypatch):
+        """A cross_sdk_compatible serializer instance is accepted AND used by the wrapper (Issue #134)."""
+        monkeypatch.setenv("CACHEKIT_MASTER_KEY", "a" * 64)
+        from cachekit.config.singleton import reset_settings
+
+        reset_settings()
+        try:
+            serializer = OrjsonSerializer()
+            assert OrjsonSerializer.cross_sdk_compatible is True
+            handler = CacheSerializationHandler(
+                serializer_name=serializer,
                 encryption=True,
                 single_tenant_mode=True,
+                deployment_uuid="00000000-0000-0000-0000-0000000000aa",
+                master_key="a" * 64,
             )
+            assert handler.encryption is True
+            wrapper = handler._get_cached_encryption_wrapper("00000000-0000-0000-0000-0000000000aa")
+            assert wrapper.serializer is serializer, "User's serializer must be threaded into the EncryptionWrapper"
+        finally:
+            reset_settings()
 
     @pytest.mark.parametrize("alias", ["default", "std"])
     def test_alias_accepted_with_encryption(self, monkeypatch, alias):


### PR DESCRIPTION
## What

Under encryption, `CacheSerializationHandler._get_cached_encryption_wrapper` built `EncryptionWrapper` **without** passing the user's base serializer, so an Arrow/orjson serializer was silently replaced by `StandardSerializer` (MessagePack). A DataFrame could not survive that substitution. The v0.6.0 hard-block validation masked the bug by rejecting every non-default serializer under encryption outright — which is why PR #133 had to delete the Arrow+encrypt integration tests (they asserted a path that never worked).

This change makes Arrow/orjson actually work under encryption and re-adds that coverage.

## Why

Per #134, the chosen fix is to thread the user's serializer into the wrapper, add a `cross_sdk_compatible` marker to the serializer contract, and loosen validation instead of hard-blocking.

- **Threading**: `_get_cached_encryption_wrapper` now passes `self._base_serializer` into `EncryptionWrapper(serializer=..., tenant_id=..., master_key=...)`. The base serializer is fixed per handler instance, so the per-tenant LRU cache key (`tenant_id`) stays correct — every wrapper for a handler wraps the same base serializer.
- **Marker**: `cross_sdk_compatible` is `True` on Standard/Orjson/Arrow (language-agnostic wire formats) and `False` on Auto (Python-specific type tags).
- **Validation**: under encryption, allow string serializers in `{default,std,standard,orjson,arrow}` and instances whose class declares `cross_sdk_compatible=True`; keep rejecting `'auto'` and unmarked custom instances with a clear `ConfigurationError`.

### Protocol design note (load-bearing)

The marker is declared as a `ClassVar` on `SerializerProtocol`'s documented contract and statically enforced via a new **non-runtime-checkable** `CrossSDKSerializerProtocol`. `SerializerProtocol` itself stays method-only at runtime on purpose: a non-method member on a `@runtime_checkable` Protocol forces **every** method-only custom serializer to declare the flag, which breaks `isinstance(x, SerializerProtocol)` on the plaintext path across Python 3.10–3.14 (verified empirically on 3.11 and 3.13; there is no version-portable way to exclude a data member from the structural check). Consumers read the flag defensively via `getattr(type(s), "cross_sdk_compatible", False)`, treating unmarked serializers as single-SDK.

## How verified

- `uv sync --group dev` then `make quick-check`: format (py/rs), lint (py/rs), type-check (basedpyright, 0 errors), critical tests, docs tests — all pass.
- `uv run pytest -k "serializer and encrypt"` (excluding `tests/fuzzing`/`tests/competitive`, which need the atheris/benchmark extras not in the dev group): **26 passed**.
- Targeted serializer + encryption suites (unit + critical + integration) on top of current `main`: **58 passed**.
- New tests: Arrow DataFrame encrypt→store→retrieve→decrypt roundtrip (integration + critical), each asserting the wrapper uses Arrow (not MessagePack), that Redis holds ciphertext, and that the DataFrame round-trips exactly.
- Updated the two unit tests in `test_encryption_security_invariants.py` that encoded the old hard-block (orjson string / orjson instance rejected) to the new contract (orjson/Arrow accepted and threaded into the wrapper; `auto` and unmarked custom instances still rejected).

**Known unrelated failure**: `make quick-check`'s doctest step fails on two pre-existing broken doctests in files this PR does not touch — `src/cachekit/backends/base.py::BaseBackend` (`NameError: backend`) and `src/cachekit/reliability/metrics_collection.py::get_all_metrics` (`NameError: clear_metrics`). Both fail on `main` independently of this change.

## Notes

- Was stacked on #148; #148 is now merged, so this targets `main` directly (per the original retarget instruction).
- Sibling overlap with #128 on `cache_handler.py` is expected.
- **Out of scope (follow-ups):** update the protocol spec (strategy/protocol repo) for Arrow/orjson-under-encryption wire-format documentation; cross-SDK Arrow+encrypt interop in cachekit-ts / cachekit-rs; refresh `docs/serializers/encryption.md`, which still implies encryption forces MessagePack.

Closes #134