### PR TITLE
fix: reject non-finite (NaN/inf) TTL to prevent immortal cache entries

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -222,7 +222,7 @@
         "filename": "src/cachekit/config/decorator.py",
         "hashed_secret": "1a9a9d37d8305b0cd8353468065cf844259e1b1f",
         "is_verified": false,
-        "line_number": 558
+        "line_number": 562
       }
     ],
     "tests/critical/test_aad_v03_security.py": [
@@ -425,5 +425,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-06T14:01:35Z"
+  "generated_at": "2026-06-07T04:43:04Z"
 }

--- a/src/cachekit/config/decorator.py
+++ b/src/cachekit/config/decorator.py
@@ -5,6 +5,7 @@ Simple frozen dataclass with nested configuration groups and validation via __po
 
 from __future__ import annotations
 
+import math
 import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -225,8 +226,11 @@ class DecoratorConfig:
             ConfigurationError: If configuration is invalid
         """
         # TTL validation
-        if self.ttl is not None and self.ttl < 0:
-            raise ValueError(f"ttl must be non-negative, got {self.ttl}")
+        if self.ttl is not None:
+            if not math.isfinite(self.ttl):
+                raise ValueError(f"ttl must be a finite number, got {self.ttl!r}")
+            if self.ttl < 0:
+                raise ValueError(f"ttl must be non-negative, got {self.ttl}")
 
         # TTL refresh threshold validation
         if not 0.0 <= self.ttl_refresh_threshold <= 1.0:

--- a/src/cachekit/l1_cache.py
+++ b/src/cachekit/l1_cache.py
@@ -5,6 +5,7 @@ dramatically reducing network latency while maintaining Redis as the source of t
 """
 
 import logging
+import math
 import random
 import threading
 import time
@@ -276,9 +277,10 @@ class L1Cache:
             # Default 5 minute TTL if not specified
             expiry = current_time + 300 - self.ttl_buffer_seconds
 
-        # Skip caching if TTL is too short (would expire immediately or already expired)
-        if expiry <= current_time:
-            logger.debug("Skipping L1 cache for key %s - TTL too short (effective TTL: %.2fs)", key, expiry - current_time)
+        # Skip caching if the effective TTL is non-finite (NaN/inf would create an
+        # immortal entry that never expires) or too short (would expire immediately).
+        if not math.isfinite(expiry) or expiry <= current_time:
+            logger.debug("Skipping L1 cache for key %s - non-finite or too-short TTL (effective expiry: %r)", key, expiry)
             return
 
         # Estimate size

--- a/src/cachekit/object_cache.py
+++ b/src/cachekit/object_cache.py
@@ -7,6 +7,7 @@ process boundaries or survive restarts.
 
 from __future__ import annotations
 
+import math
 import threading
 import time
 from collections import OrderedDict
@@ -105,8 +106,8 @@ class ObjectCache:
         Raises:
             ValueError: If ttl is less than 1.
         """
-        if ttl < 1:
-            raise ValueError(f"ttl must be >= 1, got {ttl}")
+        if not math.isfinite(ttl) or ttl < 1:
+            raise ValueError(f"ttl must be a finite number >= 1, got {ttl!r}")
         expires_at = time.monotonic() + ttl
         with self._lock:
             # If key already present, update in-place and move to end

--- a/tests/unit/config/test_decorator_config.py
+++ b/tests/unit/config/test_decorator_config.py
@@ -94,6 +94,12 @@ class TestDecoratorConfigValidation:
         with pytest.raises(ConfigurationError, match="ttl_refresh_threshold must be 0.0-1.0, got -0.1"):
             DecoratorConfig(ttl_refresh_threshold=-0.1)
 
+    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf")])
+    def test_non_finite_ttl_rejected(self, bad_ttl: float) -> None:
+        """Non-finite TTL (NaN/inf) must fail validation (#158: would create an immortal entry)."""
+        with pytest.raises(ValueError, match="finite"):
+            DecoratorConfig(ttl=bad_ttl)
+
     def test_validate_ttl_refresh_threshold_above_one(self) -> None:
         """Test validation fails for ttl_refresh_threshold > 1.0."""
         with pytest.raises(ConfigurationError, match="ttl_refresh_threshold must be 0.0-1.0, got 1.5"):

--- a/tests/unit/config/test_decorator_config.py
+++ b/tests/unit/config/test_decorator_config.py
@@ -94,7 +94,7 @@ class TestDecoratorConfigValidation:
         with pytest.raises(ConfigurationError, match="ttl_refresh_threshold must be 0.0-1.0, got -0.1"):
             DecoratorConfig(ttl_refresh_threshold=-0.1)
 
-    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf")])
+    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf"), float("-inf")])
     def test_non_finite_ttl_rejected(self, bad_ttl: float) -> None:
         """Non-finite TTL (NaN/inf) must fail validation (#158: would create an immortal entry)."""
         with pytest.raises(ValueError, match="finite"):

--- a/tests/unit/test_l1_memory_bounds.py
+++ b/tests/unit/test_l1_memory_bounds.py
@@ -62,3 +62,22 @@ class TestOversizedEntryRejection:
             cache.put(f"k{i}", b"\x00" * (300 * 1024), redis_ttl=300)  # 300KB each
         cache.put("huge", b"\x00" * (50 * MB), redis_ttl=300)  # rejected
         assert cache._current_memory_bytes <= cache.max_memory_bytes
+
+
+@pytest.mark.unit
+class TestL1NonFiniteTtl:
+    """A non-finite TTL (NaN/inf) must never produce an immortal L1 entry (#158)."""
+
+    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf")])
+    def test_non_finite_redis_ttl_not_stored(self, bad_ttl):
+        cache = L1Cache(max_memory_mb=10)
+        cache.put("k", b"value", redis_ttl=bad_ttl)
+        assert cache.get("k")[0] is False
+        assert cache._current_memory_bytes == 0
+
+    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf")])
+    def test_non_finite_expires_at_not_stored(self, bad_ttl):
+        cache = L1Cache(max_memory_mb=10)
+        cache.put("k", b"value", expires_at=bad_ttl)
+        assert cache.get("k")[0] is False
+        assert cache._current_memory_bytes == 0

--- a/tests/unit/test_l1_memory_bounds.py
+++ b/tests/unit/test_l1_memory_bounds.py
@@ -68,14 +68,14 @@ class TestOversizedEntryRejection:
 class TestL1NonFiniteTtl:
     """A non-finite TTL (NaN/inf) must never produce an immortal L1 entry (#158)."""
 
-    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf")])
+    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf"), float("-inf")])
     def test_non_finite_redis_ttl_not_stored(self, bad_ttl):
         cache = L1Cache(max_memory_mb=10)
         cache.put("k", b"value", redis_ttl=bad_ttl)
         assert cache.get("k")[0] is False
         assert cache._current_memory_bytes == 0
 
-    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf")])
+    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf"), float("-inf")])
     def test_non_finite_expires_at_not_stored(self, bad_ttl):
         cache = L1Cache(max_memory_mb=10)
         cache.put("k", b"value", expires_at=bad_ttl)

--- a/tests/unit/test_object_cache.py
+++ b/tests/unit/test_object_cache.py
@@ -73,7 +73,7 @@ class TestObjectCacheTTL:
         assert value is None
         assert oc.size == 0  # lazy removal happened
 
-    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf")])
+    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf"), float("-inf")])
     def test_non_finite_ttl_raises(self, bad_ttl: float) -> None:
         """Non-finite TTL (NaN/inf) must be rejected, not stored as an immortal entry (#158)."""
         oc = ObjectCache()

--- a/tests/unit/test_object_cache.py
+++ b/tests/unit/test_object_cache.py
@@ -73,6 +73,13 @@ class TestObjectCacheTTL:
         assert value is None
         assert oc.size == 0  # lazy removal happened
 
+    @pytest.mark.parametrize("bad_ttl", [float("nan"), float("inf")])
+    def test_non_finite_ttl_raises(self, bad_ttl: float) -> None:
+        """Non-finite TTL (NaN/inf) must be rejected, not stored as an immortal entry (#158)."""
+        oc = ObjectCache()
+        with pytest.raises(ValueError, match="finite"):
+            oc.put("k", "value", ttl=bad_ttl)
+
     def test_put_evicts_expired_before_lru(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When full, expired entries are evicted before the LRU fresh entry."""
         fake_time = types.SimpleNamespace(monotonic=lambda: 1000.0)


### PR DESCRIPTION
## Summary

Fixes #158. A `NaN` or `inf` TTL slipped past every TTL guard because they all use a `<` comparison and IEEE-754 comparisons against NaN/inf are `False`. The result was a cache entry whose expiry never triggers — stale data served indefinitely (DATA IS SACRED).

## Changes

All three TTL guard sites now reject non-finite values:

- `config/decorator.py`: `DecoratorConfig` validation rejects a non-finite `ttl` up front via `math.isfinite`, before the existing `< 0` check — so `@cache(ttl=float("nan"))` fails loud at decoration.
- `l1_cache.py`: `put()` skips caching when the computed `expiry` is non-finite (alongside the existing too-short-TTL guard), so no immortal L1 entry can form from a `NaN`/`inf` `redis_ttl` or `expires_at`.
- `object_cache.py`: `put()` rejects a non-finite `ttl` alongside the existing `ttl < 1` check.

## Tests

Unit tests (run on PRs) cover all three sites with both `NaN` and `inf`:
- `test_decorator_config.py`: non-finite ttl raises at validation
- `test_l1_memory_bounds.py`: non-finite `redis_ttl`/`expires_at` are not stored
- `test_object_cache.py`: non-finite ttl raises

## Verification

- `ruff` clean, `basedpyright` 0 errors, 52 unit tests pass across the three touched test files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened TTL validation across caching so non-finite values (NaN, ±inf) are rejected in addition to existing negative/zero checks, preventing invalid cache entries.

* **Tests**
  * Added unit tests covering non-finite TTL handling for decorator config, L1 cache and object cache to ensure correct rejection and safe memory accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->