### PR TITLE
fix: handle pandas nullable/extension dtypes in no-pyarrow DataFrame fallback

### DIFF
--- a/src/cachekit/serializers/auto_serializer.py
+++ b/src/cachekit/serializers/auto_serializer.py
@@ -668,13 +668,25 @@ class AutoSerializer:
         # Serialize each column separately
         for col in df.columns:
             series = df[col]
-            if series.dtype.name.startswith("int") or series.dtype.name.startswith("float"):
-                # Use NumPy's efficient serialization for numeric data
+            # Fast raw-buffer path only for PLAIN NumPy numeric dtypes. Pandas
+            # nullable/extension dtypes (Int64/Float64, pyarrow-backed, etc.) must NOT
+            # take this path: their .values has no .tobytes() (AttributeError), and
+            # naming is inconsistent ("Int64" misses startswith("int"); "int64[pyarrow]"
+            # wrongly matches it). is_extension_array_dtype + dtype.kind is the reliable test.
+            if not pd.api.types.is_extension_array_dtype(series.dtype) and series.dtype.kind in ("i", "u", "f"):
                 serialized["data"][col] = {"type": "numeric", "data": series.values.tobytes(), "dtype": str(series.dtype)}  # type: ignore[union-attr]
             else:
-                # Use MessagePack for other types (including datetime columns)
-                # tolist() will preserve datetime objects for our custom encoder
-                serialized["data"][col] = {"type": "object", "data": series.tolist()}
+                # Strings, datetimes, and nullable/extension columns. tolist() preserves
+                # datetime objects for our custom encoder; scalar pandas NA sentinels
+                # (pd.NA/NaT/NaN) are converted to None so msgpack can pack them.
+                values = []
+                for v in series.tolist():
+                    try:
+                        is_na = bool(pd.isna(v))
+                    except (TypeError, ValueError):
+                        is_na = False  # array-like cell (e.g. a list) is not a scalar NA
+                    values.append(None if is_na else v)
+                serialized["data"][col] = {"type": "object", "data": values}
 
         msgpack_data = msgpack.packb(serialized, **self._msgpack_pack_opts)
 

--- a/src/cachekit/serializers/auto_serializer.py
+++ b/src/cachekit/serializers/auto_serializer.py
@@ -145,6 +145,29 @@ def _wrap_tuples(obj: Any) -> Any:
     return obj
 
 
+def _is_plain_numpy_numeric(dtype: Any) -> bool:
+    """True only for a plain NumPy int/uint/float dtype.
+
+    Pandas nullable/extension dtypes (Int64, Float64, boolean, pyarrow-backed, ...)
+    are excluded: their backing arrays have no ``.tobytes()`` (AttributeError), and
+    dtype-name matching is unreliable ("Int64" misses ``startswith("int")`` while
+    "int64[pyarrow]" wrongly matches it). Used by the no-pyarrow columnar fallback.
+    """
+    return HAS_PANDAS and not pd.api.types.is_extension_array_dtype(dtype) and dtype.kind in ("i", "u", "f")
+
+
+def _na_safe_object_list(series: Any) -> list:
+    """``series.tolist()`` with scalar pandas NA sentinels (pd.NA/NaT/NaN) mapped to None.
+
+    msgpack cannot pack pd.NA/NaT. The column-level ``isna()`` mask is used (rather than
+    per-element ``pd.isna``) to avoid ambiguity on object cells that are themselves
+    array-like (e.g. a list value). Datetime objects are preserved for the custom encoder.
+    """
+    na_mask = series.isna().tolist()
+    raw = series.astype(object).tolist()
+    return [None if is_na else value for is_na, value in zip(na_mask, raw, strict=True)]
+
+
 def _auto_default(obj: Any) -> Any:
     """Custom encoder for types not natively supported by MessagePack.
 
@@ -668,25 +691,12 @@ class AutoSerializer:
         # Serialize each column separately
         for col in df.columns:
             series = df[col]
-            # Fast raw-buffer path only for PLAIN NumPy numeric dtypes. Pandas
-            # nullable/extension dtypes (Int64/Float64, pyarrow-backed, etc.) must NOT
-            # take this path: their .values has no .tobytes() (AttributeError), and
-            # naming is inconsistent ("Int64" misses startswith("int"); "int64[pyarrow]"
-            # wrongly matches it). is_extension_array_dtype + dtype.kind is the reliable test.
-            if not pd.api.types.is_extension_array_dtype(series.dtype) and series.dtype.kind in ("i", "u", "f"):
+            # Fast raw-buffer path only for plain NumPy numeric dtypes; nullable/extension
+            # dtypes fall through to the NA-safe object path (see helper docstrings).
+            if _is_plain_numpy_numeric(series.dtype):
                 serialized["data"][col] = {"type": "numeric", "data": series.values.tobytes(), "dtype": str(series.dtype)}  # type: ignore[union-attr]
             else:
-                # Strings, datetimes, and nullable/extension columns. tolist() preserves
-                # datetime objects for our custom encoder; scalar pandas NA sentinels
-                # (pd.NA/NaT/NaN) are converted to None so msgpack can pack them.
-                values = []
-                for v in series.tolist():
-                    try:
-                        is_na = bool(pd.isna(v))
-                    except (TypeError, ValueError):
-                        is_na = False  # array-like cell (e.g. a list) is not a scalar NA
-                    values.append(None if is_na else v)
-                serialized["data"][col] = {"type": "object", "data": values}
+                serialized["data"][col] = {"type": "object", "data": _na_safe_object_list(series)}
 
         msgpack_data = msgpack.packb(serialized, **self._msgpack_pack_opts)
 
@@ -747,11 +757,13 @@ class AutoSerializer:
             "index": series.index.tolist() if series.index.name or not series.index.equals(pd.RangeIndex(len(series))) else None,
         }
 
-        if series.dtype.name.startswith("int") or series.dtype.name.startswith("float"):
+        # Same dtype handling as _serialize_dataframe: plain NumPy numeric uses the raw
+        # buffer; nullable/extension dtypes take the NA-safe object path so pd.NA/NaT
+        # do not crash msgpack (#160).
+        if _is_plain_numpy_numeric(series.dtype):
             serialized.update({"type": "numeric", "data": series.values.tobytes(), "dtype": str(series.dtype)})  # type: ignore[union-attr]
         else:
-            # Use tolist() for object types - preserves datetime objects for custom encoder
-            serialized.update({"type": "object", "data": series.tolist()})
+            serialized.update({"type": "object", "data": _na_safe_object_list(series)})
 
         msgpack_data = msgpack.packb(serialized, **self._msgpack_pack_opts)
 

--- a/tests/unit/test_auto_serializer_new_types.py
+++ b/tests/unit/test_auto_serializer_new_types.py
@@ -706,3 +706,25 @@ class TestColumnarFallbackExtensionDtypes:
         out = ser._deserialize_dataframe(data)
 
         assert out["x"].tolist() == [1, 2, 3]
+
+    def test_nullable_series_roundtrip(self):
+        pd = pytest.importorskip("pandas")
+        ser = AutoSerializer(enable_integrity_checking=False)
+        s = pd.Series(pd.array([1, 2, None, 4], dtype="Int64"), name="n")
+
+        data = ser._serialize_series(s)  # previously raised on the pd.NA sentinel
+        out = ser._deserialize_series(data)
+
+        assert out.name == "n"
+        assert out.iloc[0] == 1 and out.iloc[3] == 4
+        assert pd.isna(out.iloc[2])
+
+    def test_pyarrow_backed_series_does_not_crash(self):
+        pd = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
+        ser = AutoSerializer(enable_integrity_checking=False)
+        s = pd.Series(pd.array([1, 2, 3], dtype="int64[pyarrow]"), name="x")
+
+        out = ser._deserialize_series(ser._serialize_series(s))
+
+        assert out.tolist() == [1, 2, 3]

--- a/tests/unit/test_auto_serializer_new_types.py
+++ b/tests/unit/test_auto_serializer_new_types.py
@@ -662,3 +662,47 @@ class TestPythonicSerializerAlias:
 
         s = get_serializer("pythonic")
         assert isinstance(s, AutoSerializer)
+
+
+class TestColumnarFallbackExtensionDtypes:
+    """The no-pyarrow columnar DataFrame fallback (_serialize_dataframe) must handle
+    pandas nullable/extension dtypes without crashing (#160). Round-trip is lossy on
+    this fallback (NA -> null), so we assert no-crash + value/null preservation, not
+    exact dtype fidelity (that is the Arrow path's job)."""
+
+    def test_nullable_dtypes_and_objects_roundtrip(self):
+        pd = pytest.importorskip("pandas")
+        ser = AutoSerializer(enable_integrity_checking=False)
+        df = pd.DataFrame(
+            {
+                "ints": pd.array([1, 2, None, 4], dtype="Int64"),  # capital -> missed numeric branch before
+                "floats": pd.array([1.5, 2.5, None, 4.5], dtype="Float64"),
+                "objs": ["x", None, "z", "w"],
+                "plain": [10, 20, 30, 40],  # plain numpy int64 -> fast numeric path
+            }
+        )
+
+        data = ser._serialize_dataframe(df)  # previously raised: msgpack can't pack pd.NA
+        out = ser._deserialize_dataframe(data)
+
+        assert list(out.columns) == ["ints", "floats", "objs", "plain"]
+        assert out.shape == (4, 4)
+        # Non-NA values preserved; NA positions are null after the lossy fallback.
+        assert out["ints"].iloc[0] == 1 and out["ints"].iloc[3] == 4
+        assert pd.isna(out["ints"].iloc[2])
+        assert out["objs"].iloc[0] == "x" and out["objs"].iloc[2] == "z"
+        assert pd.isna(out["objs"].iloc[1])
+        assert out["plain"].tolist() == [10, 20, 30, 40]
+
+    def test_pyarrow_backed_dtype_does_not_crash(self):
+        pd = pytest.importorskip("pandas")
+        pytest.importorskip("pyarrow")
+        ser = AutoSerializer(enable_integrity_checking=False)
+        # "int64[pyarrow]".startswith("int") was True -> hit the numeric branch ->
+        # .values.tobytes() AttributeError on the Arrow extension array, before the fix.
+        df = pd.DataFrame({"x": pd.array([1, 2, 3], dtype="int64[pyarrow]")})
+
+        data = ser._serialize_dataframe(df)
+        out = ser._deserialize_dataframe(data)
+
+        assert out["x"].tolist() == [1, 2, 3]


### PR DESCRIPTION
## Summary

Fixes #160. The columnar DataFrame fallback in `AutoSerializer._serialize_dataframe` (used only when pyarrow is absent and `serializer="auto"`) crashed on modern pandas dtypes:

- **Nullable dtypes** (`Int64`/`Float64`) have a capitalized `dtype.name`, so they missed the `startswith("int")/("float")` numeric branch, fell to the object branch, and `msgpack.packb()` raised on the `pd.NA` sentinels from `series.tolist()`.
- **pyarrow-backed dtypes** (`int64[pyarrow]`) *matched* `startswith("int")`, hit the numeric branch, and raised `AttributeError` on `series.values.tobytes()` (the Arrow extension array has no `.tobytes()`).

## Fix

- Gate the fast raw-buffer path on a **plain numpy numeric dtype** — `not pd.api.types.is_extension_array_dtype(dtype) and dtype.kind in {i,u,f}` — which is reliable where the string-name check was not (and now also covers unsigned ints).
- Make the object branch **NA-safe**: convert scalar pandas NA sentinels (`pd.NA`/`NaT`/`NaN`) to `None` so msgpack can pack them; array-like cells (e.g. a list value) are left untouched.

Round-trip through this fallback is intentionally **lossy** (NA → null; nullable dtype not preserved) — exact dtype fidelity is the Arrow path's job.

## Tests

`TestColumnarFallbackExtensionDtypes` (unit, runs on PRs):
- `Int64`/`Float64`/object columns with NA round-trip without crashing; non-NA values and null positions preserved.
- `int64[pyarrow]` column does not crash.

## Verification

- `ruff` clean, `basedpyright` 0 errors; 83 auto-serializer unit tests pass (no regression) + 2 new.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter numeric-type classification for pandas serialisation; non-eligible dtypes now use an NA-safe object fallback so missing values become nulls while preserving non-missing values.
  * Prevents crashes and improves stability for nullable/extension and pyarrow-backed columns during serialise/deserialise.

* **Tests**
  * Added coverage for nullable integer/float dtypes, object columns and series, verifying round-trip behaviour and correct handling of missing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->