### PR TITLE
fix: evict poisoned L2 entry on corruption at the read API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "src/cachekit/cache_handler.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 256
+        "line_number": 257
       }
     ],
     "src/cachekit/config/decorator.py": [
@@ -425,5 +425,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-07T04:43:04Z"
+  "generated_at": "2026-06-11T01:10:45Z"
 }

--- a/src/cachekit/cache_handler.py
+++ b/src/cachekit/cache_handler.py
@@ -854,7 +854,15 @@ class CacheOperationHandler:
                 return (True, deserialized)
             return None
         except SerializationError as e:
-            get_logger().warning(f"L2 cache decrypt/integrity failure for {cache_key}: {e}")
+            # Corruption / integrity-auth failure on the stored bytes. Best-effort evict
+            # the poisoned entry so subsequent reads don't re-pay full decompress+verify
+            # only to fail again; the caller recomputes and re-stores the value (#159).
+            get_logger().warning(f"L2 cache decrypt/integrity failure for {cache_key}; evicting poisoned entry: {e}")
+            try:
+                if self._cache_handler is not None:
+                    self._cache_handler.delete(cache_key)
+            except Exception as del_err:  # best-effort eviction; never mask the miss/recompute
+                get_logger().warning(f"Failed to evict poisoned L2 entry {cache_key}: {del_err}")
             return None
         except Exception as e:
             get_logger().warning(f"Backend operation failed for get on {cache_key}: {e}")
@@ -887,7 +895,15 @@ class CacheOperationHandler:
                 return (True, deserialized)
             return None
         except SerializationError as e:
-            get_logger().warning(f"L2 cache decrypt/integrity failure for {cache_key}: {e}")
+            # Corruption / integrity-auth failure on the stored bytes. Best-effort evict
+            # the poisoned entry so subsequent reads don't re-pay full decompress+verify
+            # only to fail again; the caller recomputes and re-stores the value (#159).
+            get_logger().warning(f"L2 cache decrypt/integrity failure for {cache_key}; evicting poisoned entry: {e}")
+            try:
+                if self._cache_handler is not None:
+                    await self._cache_handler.delete_async(cache_key)
+            except Exception as del_err:  # best-effort eviction; never mask the miss/recompute
+                get_logger().warning(f"Failed to evict poisoned L2 entry {cache_key}: {del_err}")
             return None
         except Exception as e:
             get_logger().warning(f"Backend operation failed for get on {cache_key}: {e}")

--- a/tests/unit/test_l2_decrypt_observability.py
+++ b/tests/unit/test_l2_decrypt_observability.py
@@ -76,3 +76,54 @@ class TestL2DecryptFailureWarning:
 
         result = handler.get_cached_value("test:key")
         assert result is None  # Caller will recompute
+
+    def test_serialization_error_evicts_poisoned_entry(self) -> None:
+        """On corruption, the poisoned L2 entry is deleted so reads stop re-failing (#159)."""
+        handler = self._make_handler(deserialize_side_effect=SerializationError("integrity check failed"))
+
+        result = handler.get_cached_value("poison:key")
+
+        assert result is None
+        handler._cache_handler.delete.assert_called_once_with("poison:key")
+
+    def test_eviction_failure_does_not_mask_miss(self, caplog: pytest.LogCaptureFixture) -> None:
+        """If eviction itself fails, get_cached_value still returns None (best-effort)."""
+        handler = self._make_handler(deserialize_side_effect=SerializationError("corrupt"))
+        handler._cache_handler.delete.side_effect = RuntimeError("backend down")
+
+        with caplog.at_level(logging.WARNING):
+            result = handler.get_cached_value("poison:key")
+
+        assert result is None
+        assert any("Failed to evict poisoned" in r.message for r in caplog.records)
+
+    async def test_async_serialization_error_evicts_poisoned_entry(self) -> None:
+        """Async corruption path evicts the poisoned entry via delete_async (#159)."""
+        mock_serialization = mock.MagicMock(spec=CacheSerializationHandler)
+        mock_serialization.deserialize_data.side_effect = SerializationError("integrity check failed")
+        handler = CacheOperationHandler(mock_serialization, CacheKeyGenerator())
+        mock_ch = mock.MagicMock()
+        mock_ch.get_async = mock.AsyncMock(return_value=b"corrupted-bytes")
+        mock_ch.delete_async = mock.AsyncMock(return_value=True)
+        handler.set_cache_handler(mock_ch)
+
+        result = await handler.get_cached_value_async("poison:key")
+
+        assert result is None
+        mock_ch.delete_async.assert_awaited_once_with("poison:key")
+
+    async def test_async_eviction_failure_does_not_mask_miss(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Async eviction failure must not propagate; still a miss."""
+        mock_serialization = mock.MagicMock(spec=CacheSerializationHandler)
+        mock_serialization.deserialize_data.side_effect = SerializationError("corrupt")
+        handler = CacheOperationHandler(mock_serialization, CacheKeyGenerator())
+        mock_ch = mock.MagicMock()
+        mock_ch.get_async = mock.AsyncMock(return_value=b"corrupted-bytes")
+        mock_ch.delete_async = mock.AsyncMock(side_effect=RuntimeError("backend down"))
+        handler.set_cache_handler(mock_ch)
+
+        with caplog.at_level(logging.WARNING):
+            result = await handler.get_cached_value_async("poison:key")
+
+        assert result is None
+        assert any("Failed to evict poisoned" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Refs #159. When the L2 read API catches a `SerializationError` (corruption or integrity/auth failure on the stored bytes), it now **best-effort evicts the poisoned backend entry** before returning the miss. Previously the entry survived, so every reader re-paid the full backend read + decompress + verify only to fail again before recomputing — and under a thundering herd, every waiter did.

## Changes

- `cache_handler.py`: in `CacheOperationHandler.get_cached_value` and `get_cached_value_async`, the `SerializationError` handler deletes the key (`delete` / `delete_async`) before returning `None`. Eviction errors are caught and logged — they must never mask the miss/recompute.

## Scope (honest boundary)

- The **sync** decorator path routes L2 reads through `get_cached_value`, so it is fully covered.
- The **async** decorator currently re-implements the L2 read inline (`decorators/wrapper.py:998` and the two post-lock double-checks at `:1090`/`:1116`) and bypasses `get_cached_value_async`. Those sites do **not** yet evict. The right fix is to route them through `get_cached_value_async` so they inherit eviction rather than duplicating it — a small follow-up refactor (kept out of this PR to avoid duplicating the primitive across 4 sites and adding decorator lines that only integration tests, which don't run on PRs, would cover). I'll leave #159 open for that follow-up.

## Tests

`test_l2_decrypt_observability.py` (unit, runs on PRs):
- sync + async: corruption evicts the poisoned key (`delete`/`delete_async` called once with the key);
- sync + async: eviction failure is swallowed and still returns `None` (miss).

## Verification

- `ruff` clean, `basedpyright` 0 errors; 8 tests in the file pass + 33 in the `get_cached_value` consumer files (no regression).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced cache system resilience: the cache handler now automatically removes entries that fail validation checks, rather than allowing potentially compromised data to remain cached.

* **Tests**
  * Added comprehensive test coverage for cache entry removal functionality, including scenarios where automatic removal itself fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->